### PR TITLE
Perf: Ring buffer + mutable frameRef for event pipeline (closes #2)

### DIFF
--- a/scripts/relay.ts
+++ b/scripts/relay.ts
@@ -22,6 +22,7 @@ import {
 } from '../extension/src/constants'
 import { setLogLevel } from '../extension/src/logger'
 import type { TelemetryClient } from './telemetry'
+import { RingBuffer } from '../web/lib/ring-buffer'
 
 const MAX_EVENT_BUFFER = 5000
 const DISCOVERY_DIR = path.join(os.homedir(), '.claude', 'agent-flow')
@@ -77,7 +78,7 @@ function broadcast(data: string) {
 
 // ─── Event buffering ────────────────────────────────────────────────────────
 
-const eventBuffer = new Map<string, AgentEvent[]>()
+const eventBuffer = new Map<string, RingBuffer<AgentEvent>>()
 
 /** Per-agent lifecycle events preserved outside the 5000-event buffer cap so a
  *  late-connecting client can still reconstruct the agent window even when the
@@ -154,12 +155,12 @@ function broadcastEvent(event: AgentEvent) {
   log(`[event] ${event.type} (session ${sid})`)
 
   if (event.sessionId) {
-    let buf = eventBuffer.get(event.sessionId) || []
-    buf.push(event)
-    if (buf.length > MAX_EVENT_BUFFER) {
-      buf = buf.slice(buf.length - MAX_EVENT_BUFFER)
+    let buf = eventBuffer.get(event.sessionId)
+    if (!buf) {
+      buf = new RingBuffer<AgentEvent>(MAX_EVENT_BUFFER)
+      eventBuffer.set(event.sessionId, buf)
     }
-    eventBuffer.set(event.sessionId, buf)
+    buf.push(event)
     updateAgentSnapshot(event)
   }
 
@@ -577,20 +578,55 @@ export async function createRelay(options: RelayOptions): Promise<Relay> {
         if (aActive !== bActive) return bActive - aActive
         return b.lastActivityTime - a.lastActivityTime
       })
-      for (const s of sorted) {
-        const buffered = eventBuffer.get(s.id)
-        if (buffered && buffered.length > 0) {
-          sendSSE(res, { type: 'agent-event-batch', events: buffered })
+      // Stream buffered events in chunks of ~100 to avoid a single giant
+      // JSON.stringify of the full 5 000-event buffer.
+      const REPLAY_CHUNK_SIZE = 100
+      const chunkedSessions = sorted.filter(s => {
+        const buf = eventBuffer.get(s.id)
+        return buf && buf.length > 0
+      })
+
+      if (chunkedSessions.length > 0) {
+        let sessionIdx = 0
+        let eventIdx = 0
+
+        const sendNextChunk = () => {
+          if (!sseClients.has(res)) return // client disconnected
+          while (sessionIdx < chunkedSessions.length) {
+            const buf = eventBuffer.get(chunkedSessions[sessionIdx].id)
+            if (!buf || eventIdx >= buf.length) {
+              sessionIdx++
+              eventIdx = 0
+              continue
+            }
+            const chunk: AgentEvent[] = []
+            const end = Math.min(eventIdx + REPLAY_CHUNK_SIZE, buf.length)
+            for (let i = eventIdx; i < end; i++) {
+              const evt = buf.get(i)
+              if (evt) chunk.push(evt)
+            }
+            eventIdx = end
+            if (chunk.length > 0) {
+              sendSSE(res, { type: 'agent-event-batch', events: chunk })
+            }
+            if (eventIdx < buf.length) {
+              setImmediate(sendNextChunk)
+              return
+            }
+            // Finished this session's buffered chunks — replay the preserved
+            // per-agent lifecycle snapshot so any agent whose spawn aged out
+            // of the 5000-cap ring still materializes. Handlers are idempotent
+            // (handleAgentSpawn reactivates if existing) so duplicates against
+            // the buffer are harmless.
+            const snapshot = snapshotEventsForSession(chunkedSessions[sessionIdx].id)
+            if (snapshot.length > 0) {
+              sendSSE(res, { type: 'agent-event-batch', events: snapshot })
+            }
+            sessionIdx++
+            eventIdx = 0
+          }
         }
-        // Replay preserved per-agent lifecycle events last so any agent whose
-        // spawn aged out of the 5000-cap buffer still materializes. Handlers
-        // are idempotent (handleAgentSpawn reactivates if existing) and the
-        // snapshot is always at least as fresh as the buffer, so a duplicate
-        // context_update here just confirms the latest tokens reading.
-        const snapshot = snapshotEventsForSession(s.id)
-        if (snapshot.length > 0) {
-          sendSSE(res, { type: 'agent-event-batch', events: snapshot })
-        }
+        sendNextChunk()
       }
     },
 

--- a/web/hooks/simulation/types.ts
+++ b/web/hooks/simulation/types.ts
@@ -9,6 +9,7 @@ import type {
   SimulationEvent,
 } from '@/lib/agent-types'
 import type { SimulationNodeDatum, SimulationLinkDatum } from 'd3-force'
+import { RingBuffer } from '@/lib/ring-buffer'
 
 export interface SimulationState {
   agents: Map<string, Agent>
@@ -23,7 +24,7 @@ export interface SimulationState {
   isPlaying: boolean
   speed: number
   eventIndex: number
-  eventLog: SimulationEvent[]
+  eventLog: RingBuffer<SimulationEvent>
   /** Highest currentTime ever reached (for scrubber range in live mode) */
   maxTimeReached: number
 }
@@ -43,7 +44,7 @@ export function createEmptyState(overrides?: Partial<SimulationState>): Simulati
     isPlaying: false,
     speed: 1,
     eventIndex: 0,
-    eventLog: [],
+    eventLog: new RingBuffer<SimulationEvent>(MAX_EVENT_LOG),
     maxTimeReached: 0,
     ...overrides,
   }

--- a/web/hooks/use-agent-simulation.ts
+++ b/web/hooks/use-agent-simulation.ts
@@ -17,9 +17,15 @@ import { createEmptyState, MAX_EVENT_LOG } from './simulation/types'
 import { processEvent, type ProcessEventContext } from './simulation/process-event'
 import { computeNextFrame } from './simulation/animate'
 import { snapVisualState } from './simulation/snap-visual-state'
+import { RingBuffer } from '@/lib/ring-buffer'
 
 /** ms between React state updates — canvas uses frameRef for smooth 60fps */
 const UI_THROTTLE_MS = 250
+
+/** Maximum ms of event processing allowed per animation frame.
+ *  Remaining events are deferred to the next rAF to avoid frame drops. */
+const INGEST_BUDGET_MS = 5
+
 
 export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
   const { useMockData = true, externalEvents, onExternalEventsConsumed, sessionFilter, sessionFilterRef: externalFilterRef, disable1MContext = false } = options
@@ -53,6 +59,15 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
    *  at most once per frame to coalesce burst spawns (e.g. SSE replay). */
   const forceSyncDirtyRef = useRef(false)
   const markForceSyncDirty = useCallback(() => { forceSyncDirtyRef.current = true }, [])
+  /** External events deferred from the previous frame due to time-slicing. */
+  const deferredEventsRef = useRef<SimulationEvent[]>([])
+
+  /** Produce an immutable structural snapshot of the current frameRef state.
+   *  The ring buffer is cloned so that future pushes do not mutate the snapshot. */
+  const commitSnapshot = useCallback((): SimulationState => {
+    const s = frameRef.current
+    return { ...s, eventLog: s.eventLog.clone() }
+  }, [])
 
   // ─── d3-force simulation ─────────────────────────────────────────────────
   useEffect(() => {
@@ -197,10 +212,19 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
     lastTimeRef.current = timestamp
 
     // Snapshot and consume external events OUTSIDE the main processing
-    // to avoid React strict mode double-invocation clearing them
+    // to avoid React strict mode double-invocation clearing them.
+    // Merge any deferred events from the previous frame first.
     let capturedEvents: SimulationEvent[] | null = null
+    if (deferredEventsRef.current.length > 0) {
+      capturedEvents = deferredEventsRef.current
+      deferredEventsRef.current = []
+    }
     if (externalEvents && externalEvents.length > 0 && !useMockData) {
-      capturedEvents = externalEvents.slice()
+      if (capturedEvents) {
+        capturedEvents = capturedEvents.concat(externalEvents.slice())
+      } else {
+        capturedEvents = externalEvents.slice()
+      }
       onExternalEventsConsumed?.()
     }
 
@@ -214,29 +238,40 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
     let maxT = Math.max(prev.maxTimeReached, newTime)
     let newEventIndex = prev.eventIndex
 
-    // Process events — thread state through each event
+    // Process events — mutate frameRef.current.eventLog in place via
+    // ring buffer push. No array concat / slice / state spread per event.
     let currentState = prev
-    const newEvents: SimulationEvent[] = []
+    let hadNewEvents = false
+    const ingestStart = performance.now()
 
     if (useMockData) {
       while (newEventIndex < MOCK_SCENARIO.length && MOCK_SCENARIO[newEventIndex].time <= newTime) {
+        if (performance.now() - ingestStart > INGEST_BUDGET_MS) break
         const evt = MOCK_SCENARIO[newEventIndex]
         currentState = processEventWithContext(evt, currentState)
-        newEvents.push(evt)
+        currentState.eventLog.push(evt)
+        hadNewEvents = true
         newEventIndex++
       }
     } else {
-      while (newEventIndex < currentState.eventLog.length && currentState.eventLog[newEventIndex].time <= newTime) {
-        const evt = currentState.eventLog[newEventIndex]
+      while (newEventIndex < currentState.eventLog.length) {
+        const evt = currentState.eventLog.get(newEventIndex)
+        if (!evt || evt.time > newTime) break
+        if (performance.now() - ingestStart > INGEST_BUDGET_MS) break
         currentState = processEventWithContext(evt, currentState)
         newEventIndex++
       }
     }
 
     // Process captured external events (snapshotted outside the main
-    // processing to avoid React strict mode double-invocation issues)
+    // processing to avoid React strict mode double-invocation issues).
+    // Time-sliced: if we exceed the budget, remaining events are deferred
+    // to the next rAF.
     if (capturedEvents) {
-      for (const event of capturedEvents) {
+      let i = 0
+      for (; i < capturedEvents.length; i++) {
+        if (performance.now() - ingestStart > INGEST_BUDGET_MS) break
+        const event = capturedEvents[i]
         const activeFilter = sessionFilterRef.current
         if (activeFilter && event.sessionId && event.sessionId !== activeFilter) {
           continue
@@ -245,7 +280,13 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
         const timedEvent = { ...event, time: eventTime }
         currentState = { ...currentState, currentTime: eventTime }
         currentState = processEventWithContext(timedEvent, currentState)
-        newEvents.push(timedEvent)
+        // Push directly into the ring buffer — O(1), no allocation
+        currentState.eventLog.push(timedEvent)
+        hadNewEvents = true
+      }
+      // Defer unprocessed events to next frame
+      if (i < capturedEvents.length) {
+        deferredEventsRef.current = capturedEvents.slice(i)
       }
       // Sync simulation clock to latest event so active state renders correctly
       newTime = Math.max(newTime, currentState.currentTime)
@@ -253,18 +294,9 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
 
     }
 
-    // Append new events to log
-    if (newEvents.length > 0) {
-      let newLog = currentState.eventLog.concat(newEvents)
-      if (newLog.length > MAX_EVENT_LOG) {
-        newLog = newLog.slice(newLog.length - MAX_EVENT_LOG)
-      }
-      // In mock mode, eventIndex tracks position in MOCK_SCENARIO (not the log).
-      // In live mode, eventIndex tracks position in the event log.
-      if (!useMockData) {
-        newEventIndex = newLog.length
-      }
-      currentState = { ...currentState, eventLog: newLog }
+    // In live mode, eventIndex tracks position in the event log.
+    if (hadNewEvents && !useMockData) {
+      newEventIndex = currentState.eventLog.length
     }
 
     currentState = { ...currentState, eventIndex: newEventIndex }
@@ -296,10 +328,11 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
       if (fs && fs.alpha() > fs.alphaMin()) fs.tick()
     }
 
-    // Throttle React re-renders — UI updates at ~4/sec, canvas stays smooth via frameRef
-    if (newEvents.length > 0) {
+    // Throttle React re-renders — UI updates at ~4/sec, canvas stays smooth via frameRef.
+    // commitSnapshot() produces an immutable copy so React can diff safely.
+    if (hadNewEvents) {
       if (!lastUIUpdateRef.current || timestamp - lastUIUpdateRef.current >= UI_THROTTLE_MS) {
-        setState(frameRef.current)
+        setState(commitSnapshot())
         lastUIUpdateRef.current = timestamp
       }
     }
@@ -366,9 +399,12 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
     const conversations: SimulationState['conversations'] = new Map()
     for (const id of agents.keys()) conversations.set(id, [])
 
-    const eventLog = prev.eventLog.filter(e =>
-      e.type === 'agent_spawn' && agents.has(e.payload?.name as string)
-    )
+    const eventLog = new RingBuffer<SimulationEvent>(MAX_EVENT_LOG)
+    for (const e of prev.eventLog) {
+      if (e.type === 'agent_spawn' && agents.has(e.payload?.name as string)) {
+        eventLog.push(e)
+      }
+    }
 
     const next = {
       ...createEmptyState({ isPlaying: true, speed: prev.speed }),
@@ -401,11 +437,11 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
   /** Seek to a specific time — replays events from scratch up to targetTime */
   const seekToTime = useCallback((targetTime: number) => {
     const prev = frameRef.current
-    const events = useMockData ? MOCK_SCENARIO : prev.eventLog
+    const events = useMockData ? MOCK_SCENARIO : prev.eventLog.toArray()
 
     let replayState = createEmptyState({
       speed: prev.speed,
-      eventLog: prev.eventLog,
+      eventLog: prev.eventLog.clone(),
       maxTimeReached: prev.maxTimeReached,
     })
 
@@ -430,13 +466,15 @@ export function useAgentSimulation(options: UseAgentSimulationOptions = {}) {
 
   // ─── Session state save/restore ──────────────────────────────────────────
   const saveSnapshot = useCallback((): { simState: SimulationState; blockId: number } => ({
-    simState: frameRef.current,
+    simState: commitSnapshot(),
     blockId: blockIdCounter.current,
-  }), [])
+  }), [commitSnapshot])
 
   const restoreSnapshot = useCallback((snapshot: { simState: SimulationState; blockId: number }) => {
     blockIdCounter.current = snapshot.blockId
-    commitState({ ...snapshot.simState, isPlaying: true })
+    // Clone the event log so the restored snapshot remains immutable
+    const restored = { ...snapshot.simState, isPlaying: true, eventLog: snapshot.simState.eventLog.clone() }
+    commitState(restored)
     setTimeout(() => syncForceSimulation(snapshot.simState.agents, snapshot.simState.edges), 0)
   }, [syncForceSimulation, commitState])
 

--- a/web/lib/ring-buffer.test.ts
+++ b/web/lib/ring-buffer.test.ts
@@ -1,0 +1,115 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { RingBuffer } from './ring-buffer'
+
+describe('RingBuffer', () => {
+  it('tracks length correctly', () => {
+    const buf = new RingBuffer<number>(4)
+    assert.equal(buf.length, 0)
+    buf.push(1)
+    assert.equal(buf.length, 1)
+    buf.push(2)
+    buf.push(3)
+    buf.push(4)
+    assert.equal(buf.length, 4)
+  })
+
+  it('returns elements in insertion order via get()', () => {
+    const buf = new RingBuffer<string>(4)
+    buf.push('a')
+    buf.push('b')
+    buf.push('c')
+    assert.equal(buf.get(0), 'a')
+    assert.equal(buf.get(1), 'b')
+    assert.equal(buf.get(2), 'c')
+    assert.equal(buf.get(3), undefined)
+  })
+
+  it('overwrites oldest elements when full (wrap)', () => {
+    const buf = new RingBuffer<number>(3)
+    buf.push(1)
+    buf.push(2)
+    buf.push(3)
+    // Full — next push drops 1
+    buf.push(4)
+    assert.equal(buf.length, 3)
+    assert.equal(buf.get(0), 2)
+    assert.equal(buf.get(1), 3)
+    assert.equal(buf.get(2), 4)
+  })
+
+  it('handles multiple wraps correctly', () => {
+    const buf = new RingBuffer<number>(3)
+    for (let i = 0; i < 10; i++) buf.push(i)
+    assert.equal(buf.length, 3)
+    assert.equal(buf.get(0), 7)
+    assert.equal(buf.get(1), 8)
+    assert.equal(buf.get(2), 9)
+  })
+
+  it('iterates in oldest-first order', () => {
+    const buf = new RingBuffer<number>(3)
+    buf.push(10)
+    buf.push(20)
+    buf.push(30)
+    buf.push(40) // drops 10
+    const items = [...buf]
+    assert.deepEqual(items, [20, 30, 40])
+  })
+
+  it('toArray() returns a snapshot', () => {
+    const buf = new RingBuffer<number>(3)
+    buf.push(1)
+    buf.push(2)
+    const arr = buf.toArray()
+    assert.deepEqual(arr, [1, 2])
+    // Mutating the array does not affect the buffer
+    arr.push(999)
+    assert.equal(buf.length, 2)
+  })
+
+  it('clone() produces an independent copy', () => {
+    const buf = new RingBuffer<number>(3)
+    buf.push(1)
+    buf.push(2)
+    const copy = buf.clone()
+    buf.push(3)
+    buf.push(4) // buf: [2, 3, 4]; copy: [1, 2]
+    assert.equal(copy.length, 2)
+    assert.deepEqual(copy.toArray(), [1, 2])
+    assert.deepEqual(buf.toArray(), [2, 3, 4])
+  })
+
+  it('clear() resets to empty', () => {
+    const buf = new RingBuffer<number>(3)
+    buf.push(1)
+    buf.push(2)
+    buf.clear()
+    assert.equal(buf.length, 0)
+    assert.equal(buf.get(0), undefined)
+    assert.deepEqual([...buf], [])
+  })
+
+  it('rejects capacity < 1', () => {
+    assert.throws(() => new RingBuffer<number>(0), /capacity must be >= 1/)
+    assert.throws(() => new RingBuffer<number>(-5), /capacity must be >= 1/)
+  })
+
+  it('get() returns undefined for out-of-range indices', () => {
+    const buf = new RingBuffer<number>(3)
+    buf.push(1)
+    assert.equal(buf.get(-1), undefined)
+    assert.equal(buf.get(1), undefined)
+    assert.equal(buf.get(100), undefined)
+  })
+
+  it('works with capacity 1', () => {
+    const buf = new RingBuffer<string>(1)
+    buf.push('a')
+    assert.equal(buf.get(0), 'a')
+    buf.push('b')
+    assert.equal(buf.length, 1)
+    assert.equal(buf.get(0), 'b')
+    assert.deepEqual([...buf], ['b'])
+  })
+})

--- a/web/lib/ring-buffer.ts
+++ b/web/lib/ring-buffer.ts
@@ -1,0 +1,84 @@
+/**
+ * Fixed-capacity ring buffer with O(1) push, O(1) indexed access,
+ * and an in-order iterator. When full, the oldest element is silently
+ * overwritten. All operations are allocation-free in steady state.
+ */
+export class RingBuffer<T> {
+  private readonly _buf: (T | undefined)[]
+  private readonly _capacity: number
+  /** Next write position (wraps modulo capacity). */
+  private _head = 0
+  /** Number of live elements (≤ capacity). */
+  private _length = 0
+
+  constructor(capacity: number) {
+    if (capacity < 1) throw new RangeError('RingBuffer capacity must be >= 1')
+    this._capacity = capacity
+    this._buf = new Array<T | undefined>(capacity)
+  }
+
+  /** Number of elements currently stored. */
+  get length(): number {
+    return this._length
+  }
+
+  /** Maximum number of elements before overflow. */
+  get capacity(): number {
+    return this._capacity
+  }
+
+  /** Append an element. If the buffer is full, the oldest element is dropped. O(1). */
+  push(value: T): void {
+    this._buf[this._head] = value
+    this._head = (this._head + 1) % this._capacity
+    if (this._length < this._capacity) this._length++
+  }
+
+  /**
+   * Read element at logical index `i` (0 = oldest retained element).
+   * Returns `undefined` for out-of-range indices.
+   */
+  get(i: number): T | undefined {
+    if (i < 0 || i >= this._length) return undefined
+    const start = (this._head - this._length + this._capacity) % this._capacity
+    return this._buf[(start + i) % this._capacity]
+  }
+
+  /** Iterate elements oldest-first. */
+  *[Symbol.iterator](): IterableIterator<T> {
+    const start = (this._head - this._length + this._capacity) % this._capacity
+    for (let i = 0; i < this._length; i++) {
+      yield this._buf[(start + i) % this._capacity] as T
+    }
+  }
+
+  /** Return a plain array snapshot (oldest-first). */
+  toArray(): T[] {
+    const out: T[] = new Array(this._length)
+    const start = (this._head - this._length + this._capacity) % this._capacity
+    for (let i = 0; i < this._length; i++) {
+      out[i] = this._buf[(start + i) % this._capacity] as T
+    }
+    return out
+  }
+
+  /** Remove all elements. O(1) — does not deallocate the backing array. */
+  clear(): void {
+    this._head = 0
+    this._length = 0
+  }
+
+  /**
+   * Create a shallow clone. The new buffer shares element references but
+   * has an independent write head and backing array.
+   */
+  clone(): RingBuffer<T> {
+    const copy = new RingBuffer<T>(this._capacity)
+    copy._head = this._head
+    copy._length = this._length
+    for (let i = 0; i < this._capacity; i++) {
+      copy._buf[i] = this._buf[i]
+    }
+    return copy
+  }
+}


### PR DESCRIPTION
## Summary

- **New `RingBuffer<T>` data structure** (`web/lib/ring-buffer.ts`) — O(1) push, indexed access, iterator, and clone. Replaces the `SimulationEvent[]` eventLog with a fixed-capacity ring buffer that silently drops oldest events when full, eliminating per-event `concat` + `slice` allocations.
- **Mutable frameRef ingest + `commitSnapshot()`** — external events are pushed directly into `frameRef.current.eventLog` (the ring buffer) during the rAF loop. An immutable structural copy is produced only at the 4 Hz React commit boundary via `commitSnapshot()`, which clones the ring buffer. Time-sliced ingestion caps per-frame event processing to ~5 ms, deferring the rest to the next rAF.
- **Relay-side ring buffer + chunked SSE replay** — `scripts/relay.ts` per-session event buffer replaced with `RingBuffer<AgentEvent>`. SSE replay streams events in chunks of ~100 with `setImmediate` between chunks instead of `JSON.stringify`-ing the entire 5000-event buffer in one shot.

### Files not touched (parallel issues)
`session-stats-provider.tsx`, `cost-summary-panel.tsx`, `message-feed-panel.tsx`, `canvas.tsx`, `canvas/`, `bloom-renderer.ts`, and `index.tsx` feedConversations/feedAgents/agentToSession denormalization are all owned by other issues.

## Test plan

- [x] `npx tsx --test web/lib/ring-buffer.test.ts` — 11 unit tests (push, overflow wrap, iterator order, length, clone, clear, capacity-1 edge case)
- [x] `cd extension && pnpm test` — all 28 existing tests pass (relay watcher tests sensitive to event-buffer shape)
- [x] `cd web && npx tsc --noEmit` — zero type errors
- [x] `cd web && pnpm build` — clean production build
- [ ] **Manual**: `pnpm sim stress` — verify 500 events process without frame drops in `?perf` overlay (P95 frame time < 20 ms)
- [ ] **Manual**: DevTools heap-snapshot diff — confirm no new state-object allocations per event in steady-state ingest loop
- [ ] **Manual**: verify seek/restart/save-restore still work correctly with ring buffer eventLog

🤖 Generated with [Claude Code](https://claude.com/claude-code)