### PR TITLE
Perf: Pixi edges layer (closes #11)

### DIFF
--- a/web/components/agent-visualizer/pixi/edges-layer.test.ts
+++ b/web/components/agent-visualizer/pixi/edges-layer.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Unit tests for EdgesLayer — validates rope creation, pooling, disposal,
+ * and active/idle tint assignment.
+ *
+ * Run with: cd web && pnpm test
+ *
+ * Since EdgesLayer depends on pixi.js (browser-only), we mock the Pixi
+ * primitives and BezierCache to test the logic in isolation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ─── Mock pixi.js before importing EdgesLayer ──────────────────────────────
+// vi.mock factories are hoisted — all definitions must be self-contained.
+
+vi.mock('pixi.js', () => {
+  class MockPoint {
+    x: number
+    y: number
+    constructor(x = 0, y = 0) { this.x = x; this.y = y }
+  }
+
+  class MockContainer {
+    label = ''
+    children: unknown[] = []
+    addChild(child: unknown) { this.children.push(child) }
+    removeChild(child: unknown) {
+      const idx = this.children.indexOf(child)
+      if (idx >= 0) this.children.splice(idx, 1)
+    }
+    destroy() { this.children.length = 0 }
+  }
+
+  class MockMeshRope {
+    label = ''
+    tint = 0xffffff
+    alpha = 1
+    visible = true
+    texture: unknown
+    points: InstanceType<typeof MockPoint>[]
+    width: number
+    constructor(opts: { texture: unknown; points: InstanceType<typeof MockPoint>[]; width?: number }) {
+      this.texture = opts.texture
+      this.points = opts.points
+      this.width = opts.width ?? 1
+    }
+    destroy() { /* no-op */ }
+  }
+
+  return {
+    Container: MockContainer,
+    MeshRope: MockMeshRope,
+    Point: MockPoint,
+    Texture: { from: () => ({ destroy: () => {} }) },
+  }
+})
+
+// ─── Mock BezierCache ──────────────────────────────────────────────────────
+
+// vi.hoisted lets us define variables that vi.mock factories can reference.
+const { mockBezierCacheGet, mockBezierCachePrune, mockBezierCacheClear } = vi.hoisted(() => ({
+  mockBezierCacheGet: vi.fn(),
+  mockBezierCachePrune: vi.fn(),
+  mockBezierCacheClear: vi.fn(),
+}))
+
+vi.mock('./bezier-cache', () => ({
+  BezierCache: class {
+    get = mockBezierCacheGet
+    prune = mockBezierCachePrune
+    clear = mockBezierCacheClear
+  },
+}))
+
+// ─── Mock canvas/draw-edges ────────────────────────────────────────────────
+
+vi.mock('../canvas/draw-edges', () => ({
+  getActiveEdgeIds: (particles: Array<{ edgeId: string }>) => {
+    const ids = new Set<string>()
+    for (const p of particles) ids.add(p.edgeId)
+    return ids
+  },
+}))
+
+// ─── Mock canvas-constants ─────────────────────────────────────────────────
+
+vi.mock('@/lib/canvas-constants', () => ({
+  MIN_VISIBLE_OPACITY: 0,
+}))
+
+// ─── Import EdgesLayer after mocks ─────────────────────────────────────────
+
+import { EdgesLayer } from './edges-layer'
+import type { Edge, Agent, Particle, ToolCallNode } from '@/lib/agent-types'
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+const mockPolylineSamples = Array.from({ length: 33 }, (_, i) => ({
+  x: i * 10, y: i * 5, nx: 0, ny: 1,
+}))
+
+function mockPolyline(edgeId: string) {
+  return {
+    edgeId,
+    fromX: 0, fromY: 0, toX: 320, toY: 160,
+    samples: mockPolylineSamples,
+    cp1x: 100, cp1y: 50, cp2x: 200, cp2y: 100,
+    dist: 357, dx: 320, dy: 160,
+  }
+}
+
+function makeEdge(id: string, from: string, to: string, type: 'parent-child' | 'tool' = 'parent-child'): Edge {
+  return { id, from, to, type, opacity: 1 }
+}
+
+function makeAgent(id: string, x = 0, y = 0): Agent {
+  return {
+    id, name: id, x, y, opacity: 1,
+    state: 'thinking', color: '#66ccff',
+    radius: 20, targetX: x, targetY: y, vx: 0, vy: 0,
+    pinned: false, contextWindow: { used: 0, max: 100000 },
+  } as unknown as Agent
+}
+
+function makeParticle(edgeId: string): Particle {
+  return {
+    id: `p-${edgeId}`,
+    edgeId,
+    progress: 0.5,
+    type: 'dispatch',
+    color: '#66ccff',
+    size: 3,
+    trailLength: 8,
+  }
+}
+
+function makeToolCall(id: string, x = 0, y = 0): ToolCallNode {
+  return {
+    id, name: id, x, y, opacity: 1,
+    state: 'running', agentId: 'a1',
+  } as unknown as ToolCallNode
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('EdgesLayer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Set up default mock: return a polyline for any edge
+    mockBezierCacheGet.mockImplementation(
+      (edge: { id: string }) => mockPolyline(edge.id),
+    )
+  })
+
+  it('spawns one display object per edge', () => {
+    const layer = new EdgesLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1', 0, 0)],
+      ['a2', makeAgent('a2', 100, 100)],
+      ['a3', makeAgent('a3', 200, 200)],
+    ])
+    const edges = [
+      makeEdge('e1', 'a1', 'a2'),
+      makeEdge('e2', 'a1', 'a3'),
+      makeEdge('e3', 'a2', 'a3'),
+    ]
+
+    layer.update(edges, [], agents, new Map(), 0)
+
+    expect(layer.entryCount).toBe(3)
+    expect(layer.container.children.length).toBe(3)
+  })
+
+  it('does not allocate new ropes when the same edge set is passed again', () => {
+    const layer = new EdgesLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1', 0, 0)],
+      ['a2', makeAgent('a2', 100, 100)],
+    ])
+    const edges = [makeEdge('e1', 'a1', 'a2')]
+
+    layer.update(edges, [], agents, new Map(), 0)
+    const firstEntry = layer.getEntry('e1')
+    expect(firstEntry).toBeDefined()
+
+    // Second update with same edges — should reuse the existing rope
+    layer.update(edges, [], agents, new Map(), 1)
+    const secondEntry = layer.getEntry('e1')
+
+    expect(secondEntry).toBe(firstEntry)
+    expect(layer.entryCount).toBe(1)
+  })
+
+  it('dispose removes all display objects from the container', () => {
+    const layer = new EdgesLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1', 0, 0)],
+      ['a2', makeAgent('a2', 100, 100)],
+    ])
+    const edges = [makeEdge('e1', 'a1', 'a2')]
+
+    layer.update(edges, [], agents, new Map(), 0)
+    expect(layer.entryCount).toBe(1)
+
+    layer.dispose()
+
+    expect(layer.entryCount).toBe(0)
+  })
+
+  it('active edges get the active alpha; idle edges get the idle alpha', () => {
+    const layer = new EdgesLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1', 0, 0)],
+      ['a2', makeAgent('a2', 100, 100)],
+      ['a3', makeAgent('a3', 200, 200)],
+    ])
+    const edges = [
+      makeEdge('e1', 'a1', 'a2'),
+      makeEdge('e2', 'a1', 'a3'),
+    ]
+    // Only e1 has a particle — so e1 is active, e2 is idle
+    const particles = [makeParticle('e1')]
+
+    layer.update(edges, particles, agents, new Map(), 0)
+
+    const activeEntry = layer.getEntry('e1')
+    const idleEntry = layer.getEntry('e2')
+
+    expect(activeEntry).toBeDefined()
+    expect(idleEntry).toBeDefined()
+
+    // Active edge alpha should be higher than idle edge alpha.
+    // BEAM.activeAlpha = 0.3, BEAM.idleAlpha = 0.08
+    // Active alpha is modulated by pulsing: sin(0 * 4) * 0.1 + 0.9 = 0.9
+    // So active alpha = 0.3 * 0.9 = 0.27, idle = 0.08 * 1 = 0.08
+    expect(activeEntry!.rope.alpha).toBeGreaterThan(idleEntry!.rope.alpha)
+  })
+
+  it('active edges get the correct tint for their type', () => {
+    const layer = new EdgesLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1', 0, 0)],
+      ['a2', makeAgent('a2', 100, 100)],
+    ])
+    const toolCalls = new Map<string, ToolCallNode>([
+      ['t1', makeToolCall('t1', 200, 200)],
+    ])
+    const edges = [
+      makeEdge('e1', 'a1', 'a2', 'parent-child'),
+      makeEdge('e2', 'a1', 't1', 'tool'),
+    ]
+
+    layer.update(edges, [], agents, toolCalls, 0)
+
+    const parentChildEntry = layer.getEntry('e1')
+    const toolEntry = layer.getEntry('e2')
+
+    // COLORS.holoBase = '#66ccff' -> 0x66ccff
+    expect(parentChildEntry!.rope.tint).toBe(0x66ccff)
+    // COLORS.tool = '#ffbb44' -> 0xffbb44
+    expect(toolEntry!.rope.tint).toBe(0xffbb44)
+  })
+
+  it('hides ropes for edges that disappear between frames', () => {
+    const layer = new EdgesLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1', 0, 0)],
+      ['a2', makeAgent('a2', 100, 100)],
+      ['a3', makeAgent('a3', 200, 200)],
+    ])
+
+    // Frame 1: two edges
+    layer.update(
+      [makeEdge('e1', 'a1', 'a2'), makeEdge('e2', 'a1', 'a3')],
+      [], agents, new Map(), 0,
+    )
+    expect(layer.getEntry('e1')!.rope.visible).toBe(true)
+    expect(layer.getEntry('e2')!.rope.visible).toBe(true)
+
+    // Frame 2: only e1 remains
+    layer.update(
+      [makeEdge('e1', 'a1', 'a2')],
+      [], agents, new Map(), 1,
+    )
+    expect(layer.getEntry('e1')!.rope.visible).toBe(true)
+    expect(layer.getEntry('e2')!.rope.visible).toBe(false)
+  })
+})

--- a/web/components/agent-visualizer/pixi/edges-layer.ts
+++ b/web/components/agent-visualizer/pixi/edges-layer.ts
@@ -1,0 +1,212 @@
+/**
+ * Edge rendering layer — one MeshRope per edge, driven by precomputed
+ * polyline samples from BezierCache.
+ *
+ * Active edges (those with particles) get brighter tint + higher alpha;
+ * idle edges are dimmer. A time-based pulse modulates active-edge alpha
+ * to match the Canvas2D path's animation.
+ *
+ * Follows the same pattern as ParticlesLayer: constructor creates a
+ * Container, update() is called once per rAF tick, dispose() tears down.
+ */
+
+import { Container, MeshRope, Point, Texture } from 'pixi.js'
+import type { Agent, Edge, Particle, ToolCallNode } from '@/lib/agent-types'
+import { BEAM, ANIM } from '@/lib/agent-types'
+import { COLORS } from '@/lib/colors'
+import { MIN_VISIBLE_OPACITY } from '@/lib/canvas-constants'
+import { getActiveEdgeIds } from '../canvas/draw-edges'
+import { BezierCache } from './bezier-cache'
+
+/** Persistent state for a single edge rope. */
+interface EdgeEntry {
+  rope: MeshRope
+  /** The point objects fed to MeshRope — mutated in-place each frame. */
+  points: Point[]
+  /** Edge id this entry is keyed to. */
+  edgeId: string
+}
+
+/** Parse a CSS hex color to a numeric tint (e.g. '#66ccff' -> 0x66ccff). */
+function parseHexColor(hex: string): number {
+  if (hex.startsWith('#')) {
+    return parseInt(hex.slice(1, 7), 16)
+  }
+  return 0xffffff
+}
+
+/** Width of the rope texture in pixels. The texture is a 1-pixel-tall white
+ *  strip — the rope's visual width is controlled by the texture height and
+ *  the `width` option on MeshRope. */
+const ROPE_TEXTURE_SIZE = 4
+
+/** Lazily created 1×N white texture for MeshRope. */
+let ropeTexture: Texture | null = null
+
+function getRopeTexture(): Texture {
+  if (ropeTexture) return ropeTexture
+  const canvas = document.createElement('canvas')
+  canvas.width = ROPE_TEXTURE_SIZE
+  canvas.height = ROPE_TEXTURE_SIZE
+  const ctx = canvas.getContext('2d')
+  if (ctx) {
+    ctx.fillStyle = '#ffffff'
+    ctx.fillRect(0, 0, ROPE_TEXTURE_SIZE, ROPE_TEXTURE_SIZE)
+  }
+  ropeTexture = Texture.from(canvas)
+  return ropeTexture
+}
+
+/**
+ * Manages the edge rendering layer. Owns a Container that the caller adds
+ * to the Pixi stage. Call `update()` each frame with the current simulation
+ * state to position and style ropes.
+ */
+export class EdgesLayer {
+  readonly container: Container
+
+  /** Persistent rope entries keyed by edge id. */
+  private entries = new Map<string, EdgeEntry>()
+
+  /** Shared bezier cache (same instance the particles layer would use,
+   *  but edges-layer owns its own to avoid coupling). */
+  private readonly bezierCache: BezierCache
+
+  /** Tint values for tool vs parent-child edges, precomputed once. */
+  private readonly toolTint: number
+  private readonly parentChildTint: number
+
+  constructor() {
+    this.container = new Container()
+    this.container.label = 'edges'
+    this.bezierCache = new BezierCache()
+    this.toolTint = parseHexColor(COLORS.tool)
+    this.parentChildTint = parseHexColor(COLORS.holoBase)
+  }
+
+  /**
+   * Update all edge ropes for the current frame.
+   * Called once per rAF tick from pixi-canvas.tsx.
+   */
+  update(
+    edges: Edge[],
+    particles: Particle[],
+    agents: Map<string, Agent>,
+    toolCalls: Map<string, ToolCallNode>,
+    time: number,
+  ): void {
+    const activeEdgeIds = getActiveEdgeIds(particles)
+
+    // Track which edge ids are still alive this frame
+    const aliveIds = new Set<string>()
+
+    for (const edge of edges) {
+      const fromAgent = agents.get(edge.from)
+      if (!fromAgent || fromAgent.opacity < MIN_VISIBLE_OPACITY) continue
+
+      // Resolve edge target
+      const toAgent = agents.get(edge.to)
+      const toTool = toolCalls.get(edge.to)
+      const target = (toAgent && toAgent.opacity >= MIN_VISIBLE_OPACITY)
+        ? toAgent
+        : (toTool && toTool.opacity >= MIN_VISIBLE_OPACITY)
+          ? toTool
+          : null
+      if (!target) continue
+
+      const polyline = this.bezierCache.get(edge, agents, toolCalls)
+      if (!polyline) continue
+
+      aliveIds.add(edge.id)
+
+      const hasActive = activeEdgeIds.has(edge.id)
+      const baseAlpha = hasActive ? BEAM.activeAlpha : BEAM.idleAlpha
+      const pulsing = hasActive
+        ? Math.sin(time * ANIM.pulseSpeed) * 0.1 + 0.9
+        : 1
+      const tint = edge.type === 'tool' ? this.toolTint : this.parentChildTint
+      const beamWidth = edge.type === 'tool' ? BEAM.tool.startW : BEAM.parentChild.startW
+
+      let entry = this.entries.get(edge.id)
+
+      if (!entry) {
+        // Create new rope for this edge
+        const points = polyline.samples.map(s => new Point(s.x, s.y))
+        const rope = new MeshRope({
+          texture: getRopeTexture(),
+          points,
+          width: beamWidth,
+        })
+        rope.label = `edge-${edge.id}`
+        this.container.addChild(rope)
+        entry = { rope, points, edgeId: edge.id }
+        this.entries.set(edge.id, entry)
+      } else {
+        // Update existing rope's point positions from the cache
+        const samples = polyline.samples
+        const pts = entry.points
+
+        // If sample count changed (shouldn't normally), rebuild points array
+        if (pts.length !== samples.length) {
+          const newPoints = samples.map(s => new Point(s.x, s.y))
+          // MeshRope in v8 uses RopeGeometry constructed from the points array.
+          // We must replace the rope since the geometry's vertex count is fixed.
+          entry.rope.destroy()
+          this.container.removeChild(entry.rope)
+          const rope = new MeshRope({
+            texture: getRopeTexture(),
+            points: newPoints,
+            width: beamWidth,
+          })
+          rope.label = `edge-${edge.id}`
+          this.container.addChild(rope)
+          entry.rope = rope
+          entry.points = newPoints
+        } else {
+          // Mutate point positions in-place — MeshRope auto-updates geometry
+          for (let i = 0; i < samples.length; i++) {
+            pts[i].x = samples[i].x
+            pts[i].y = samples[i].y
+          }
+        }
+      }
+
+      // Style the rope
+      entry.rope.tint = tint
+      entry.rope.alpha = baseAlpha * pulsing
+      entry.rope.visible = true
+    }
+
+    // Hide ropes for edges no longer present
+    for (const [id, entry] of this.entries) {
+      if (!aliveIds.has(id)) {
+        entry.rope.visible = false
+      }
+    }
+
+    // Prune bezier cache entries for edges that no longer exist in the
+    // simulation. Use aliveIds (edges that resolved to valid endpoints
+    // this frame) rather than all edge ids, mirroring particles-layer.
+    this.bezierCache.prune(aliveIds)
+  }
+
+  /** Release GPU resources and remove all display objects. */
+  dispose(): void {
+    this.bezierCache.clear()
+    for (const entry of this.entries.values()) {
+      entry.rope.destroy()
+    }
+    this.entries.clear()
+    this.container.destroy({ children: true })
+  }
+
+  /** Number of active edge entries — useful for tests. */
+  get entryCount(): number {
+    return this.entries.size
+  }
+
+  /** Retrieve a rope entry by edge id — useful for tests. */
+  getEntry(edgeId: string): EdgeEntry | undefined {
+    return this.entries.get(edgeId)
+  }
+}

--- a/web/components/agent-visualizer/pixi/pixi-canvas.tsx
+++ b/web/components/agent-visualizer/pixi/pixi-canvas.tsx
@@ -18,6 +18,7 @@ import type { SimulationState } from '@/hooks/simulation/types'
 import { useCanvasCamera } from '@/hooks/use-canvas-camera'
 import { useCanvasInteraction } from '@/hooks/use-canvas-interaction'
 import { createPixiApp, disposeTextureCache } from './pixi-app'
+import { EdgesLayer } from './edges-layer'
 import { ParticlesLayer } from './particles-layer'
 import { applyCameraTransform } from './camera'
 
@@ -70,6 +71,7 @@ export function PixiCanvas({
 }: CanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const appRef = useRef<Application | null>(null)
+  const edgesLayerRef = useRef<EdgesLayer | null>(null)
   const particlesLayerRef = useRef<ParticlesLayer | null>(null)
   const worldRef = useRef<Container | null>(null)
   const animRef = useRef<number>(0)
@@ -180,7 +182,7 @@ export function PixiCanvas({
   // Only the particles layer is functional in this spike.
 
   // TODO: background-layer (depth particles + hex grid)
-  // TODO: edges-layer (MeshRope or batched line geometry)
+  // edges-layer (MeshRope) — implemented
   // TODO: agents-layer (sprite + text)
   // TODO: tool-calls-layer (sprite + text)
   // TODO: discoveries-layer (sprite + text)
@@ -226,6 +228,11 @@ export function PixiCanvas({
       app.stage.addChild(world)
       worldRef.current = world
 
+      // Edges layer (behind particles in z-order, matching Canvas2D draw order)
+      const edgesLayer = new EdgesLayer()
+      world.addChild(edgesLayer.container)
+      edgesLayerRef.current = edgesLayer
+
       // Particles layer (functional)
       const particlesLayer = new ParticlesLayer()
       world.addChild(particlesLayer.container)
@@ -261,6 +268,15 @@ export function PixiCanvas({
         // Apply camera transform to the world container
         applyCameraTransform(world, transformRef.current)
 
+        // Update edges layer (drawn behind particles)
+        edgesLayer.update(
+          s.edges,
+          s.particles,
+          s.agents,
+          s.toolCalls,
+          timeRef.current,
+        )
+
         // Update particles layer
         particlesLayer.update(
           s.particles,
@@ -279,6 +295,10 @@ export function PixiCanvas({
     return () => {
       destroyed = true
       if (animRef.current) cancelAnimationFrame(animRef.current)
+      if (edgesLayerRef.current) {
+        edgesLayerRef.current.dispose()
+        edgesLayerRef.current = null
+      }
       if (particlesLayerRef.current) {
         particlesLayerRef.current.destroy()
         particlesLayerRef.current = null


### PR DESCRIPTION
## Summary

- Add `web/components/agent-visualizer/pixi/edges-layer.ts` -- one `MeshRope` per edge driven by precomputed polyline samples from `BezierCache`, with active/idle styling (tint + alpha) and time-based pulse animation matching the Canvas2D path
- Wire `EdgesLayer` into `pixi-canvas.tsx`: mounted behind `ParticlesLayer` in z-order, updated once per rAF tick, properly disposed on unmount
- Add 6 unit tests covering rope creation, object pooling (no re-allocation on stable edge set), disposal, active/idle alpha, type-based tint, and edge disappearance

## Design decisions

- **MeshRope** chosen over batched line geometry for v1 simplicity -- one draw call per edge, auto-updates geometry when point positions are mutated in-place
- **Lazy rope texture**: a small 4x4 white canvas texture created on first use (null-safe for jsdom test environment)
- **Reuses** `getActiveEdgeIds` from `canvas/draw-edges.ts` and `BezierCache` from `pixi/bezier-cache.ts` -- no duplication of edge logic
- **Rope pooling**: ropes persist across frames; hidden via `visible = false` when their edge disappears rather than destroyed immediately

## Test plan

- [x] `cd web && pnpm typecheck` -- zero errors
- [x] `cd web && pnpm test` -- 7 files, 58 tests pass (6 new edges-layer tests)
- [x] `cd web && pnpm build` -- builds successfully
- [x] `cd web && pnpm build:webview` -- builds successfully
- [x] `cd extension && pnpm test` -- 28 tests pass (no regressions)
- [ ] **Manual**: `pnpm dev`, open `http://localhost:3000?renderer=pixi`, run `pnpm sim subagents` -- verify edges render between agents/tool-calls with:
  - Active edges (with particles) brighter, with pulse animation
  - Idle edges dimmer
  - Tool edges amber tint, parent-child edges blue tint
  - Edges drawn behind particles
- [ ] **Manual**: open `http://localhost:3000` (no flag) -- verify default Canvas2D path is unchanged
- [ ] **Manual**: compare edge styling side-by-side between `?renderer=pixi` and default Canvas2D

## Follow-up issues

None filed -- no blockers or scope cuts encountered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)