### PR TITLE
Perf: Pixi agents layer + glyph atlas (closes #12)

### DIFF
--- a/web/components/agent-visualizer/pixi/agents-layer.test.ts
+++ b/web/components/agent-visualizer/pixi/agents-layer.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Unit tests for AgentsLayer — validates entry creation, pooling, selection
+ * ring visibility, tint changes, and disposal.
+ *
+ * Run with: cd web && pnpm test
+ *
+ * Mocks pixi.js and GlyphAtlas to test logic in isolation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ─── Mock pixi.js before importing AgentsLayer ──────────────────────────
+
+vi.mock('pixi.js', () => {
+  class MockContainer {
+    label = ''
+    children: unknown[] = []
+    x = 0
+    y = 0
+    alpha = 1
+    visible = true
+    addChild(child: unknown) { this.children.push(child) }
+    removeChild(child: unknown) {
+      const idx = this.children.indexOf(child)
+      if (idx >= 0) this.children.splice(idx, 1)
+    }
+    destroy(_opts?: unknown) { this.children.length = 0 }
+  }
+
+  class MockSprite {
+    label = ''
+    x = 0
+    y = 0
+    tint = 0xffffff
+    alpha = 1
+    visible = true
+    texture: unknown
+    _anchorX = 0
+    _anchorY = 0
+    _scaleX = 1
+    _scaleY = 1
+    anchor = {
+      set: (x: number, y?: number) => {
+        this._anchorX = x
+        this._anchorY = y ?? x
+      },
+    }
+    scale = {
+      set: (x: number, y?: number) => {
+        this._scaleX = x
+        this._scaleY = y ?? x
+      },
+    }
+    constructor(texture?: unknown) { this.texture = texture }
+    destroy() { /* no-op */ }
+  }
+
+  class MockGraphics {
+    label = ''
+    visible = true
+    _cleared = false
+    _lastCircleR = 0
+    clear() { this._cleared = true; return this }
+    circle(_x: number, _y: number, r: number) { this._lastCircleR = r; return this }
+    stroke(_opts: unknown) { return this }
+    fill(_opts: unknown) { return this }
+    destroy() { /* no-op */ }
+  }
+
+  return {
+    Container: MockContainer,
+    Sprite: MockSprite,
+    Graphics: MockGraphics,
+    Texture: { from: () => ({ destroy: () => {} }) },
+    Rectangle: class { constructor(public x = 0, public y = 0, public width = 0, public height = 0) {} },
+  }
+})
+
+// ─── Mock pixi-app (getCircleTexture) ────────────────────────────────────
+
+vi.mock('./pixi-app', () => ({
+  getCircleTexture: () => ({ destroy: () => {} }),
+}))
+
+// ─── Mock GlyphAtlas ─────────────────────────────────────────────────────
+
+vi.mock('./glyph-atlas', () => ({
+  GlyphAtlas: class {
+    getGlyph(text: string, color: string, fontSize?: number) {
+      return {
+        texture: { destroy: () => {}, source: {} },
+        width: text.length * 6,
+        height: (fontSize ?? 10) * 1.4,
+      }
+    }
+    dispose() { /* no-op */ }
+  },
+}))
+
+// ─── Import after mocks ──────────────────────────────────────────────────
+
+import { AgentsLayer } from './agents-layer'
+import type { Agent } from '@/lib/agent-types'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+function makeAgent(id: string, overrides: Partial<Agent> = {}): Agent {
+  return {
+    id,
+    name: id,
+    state: 'thinking',
+    parentId: null,
+    tokensUsed: 5000,
+    tokensMax: 200000,
+    contextBreakdown: { systemPrompt: 1000, userMessages: 2000, toolResults: 1000, reasoning: 500, subagentResults: 500 },
+    toolCalls: 3,
+    timeAlive: 12.5,
+    x: 100,
+    y: 200,
+    vx: 0,
+    vy: 0,
+    pinned: false,
+    isMain: true,
+    spawnTime: 0,
+    opacity: 1,
+    scale: 1,
+    messageBubbles: [],
+    ...overrides,
+  } as Agent
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+
+describe('AgentsLayer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('N agents creates N display containers', () => {
+    const layer = new AgentsLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1')],
+      ['a2', makeAgent('a2')],
+      ['a3', makeAgent('a3')],
+    ])
+
+    layer.update(agents, null, null, false, 0)
+
+    expect(layer.entryCount).toBe(3)
+    expect(layer.container.children.length).toBe(3)
+  })
+
+  it('same agent set on consecutive frames does not allocate new entries', () => {
+    const layer = new AgentsLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1')],
+      ['a2', makeAgent('a2')],
+    ])
+
+    layer.update(agents, null, null, false, 0)
+    const entry1 = layer.getEntry('a1')
+    expect(entry1).toBeDefined()
+
+    // Second update — same agents
+    layer.update(agents, null, null, false, 1)
+    const entry2 = layer.getEntry('a1')
+
+    expect(entry2).toBe(entry1)
+    expect(layer.entryCount).toBe(2)
+  })
+
+  it('selection ring visibility tracks selectedAgentId', () => {
+    const layer = new AgentsLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1')],
+      ['a2', makeAgent('a2')],
+    ])
+
+    // Select a1
+    layer.update(agents, 'a1', null, false, 0)
+
+    expect(layer.getEntry('a1')!.selectionRing.visible).toBe(true)
+    expect(layer.getEntry('a2')!.selectionRing.visible).toBe(false)
+
+    // Select a2
+    layer.update(agents, 'a2', null, false, 1)
+
+    expect(layer.getEntry('a1')!.selectionRing.visible).toBe(false)
+    expect(layer.getEntry('a2')!.selectionRing.visible).toBe(true)
+
+    // Deselect all
+    layer.update(agents, null, null, false, 2)
+
+    expect(layer.getEntry('a1')!.selectionRing.visible).toBe(false)
+    expect(layer.getEntry('a2')!.selectionRing.visible).toBe(false)
+  })
+
+  it('state change toggles tint without recreating sprites', () => {
+    const layer = new AgentsLayer()
+    const agent = makeAgent('a1', { state: 'thinking' })
+    const agents = new Map<string, Agent>([['a1', agent]])
+
+    layer.update(agents, null, null, false, 0)
+    const entry = layer.getEntry('a1')!
+    const bodyRef = entry.body
+
+    // Thinking state tint: #66ccff = 0x66ccff
+    expect(entry.body.tint).toBe(0x66ccff)
+
+    // Change state to tool_calling
+    agent.state = 'tool_calling'
+    layer.update(agents, null, null, false, 1)
+
+    // Body should be the same object (no reallocation)
+    expect(entry.body).toBe(bodyRef)
+    // tool_calling: #ffbb44 = 0xffbb44
+    expect(entry.body.tint).toBe(0xffbb44)
+  })
+
+  it('hover halo visibility tracks hoveredAgentId', () => {
+    const layer = new AgentsLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1')],
+      ['a2', makeAgent('a2')],
+    ])
+
+    layer.update(agents, null, 'a1', false, 0)
+
+    expect(layer.getEntry('a1')!.hoverHalo.visible).toBe(true)
+    expect(layer.getEntry('a2')!.hoverHalo.visible).toBe(false)
+
+    layer.update(agents, null, null, false, 1)
+
+    expect(layer.getEntry('a1')!.hoverHalo.visible).toBe(false)
+  })
+
+  it('dispose cleans up all entries', () => {
+    const layer = new AgentsLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1')],
+      ['a2', makeAgent('a2')],
+    ])
+
+    layer.update(agents, null, null, false, 0)
+    expect(layer.entryCount).toBe(2)
+
+    layer.dispose()
+
+    expect(layer.entryCount).toBe(0)
+  })
+
+  it('agents that disappear between frames are hidden', () => {
+    const layer = new AgentsLayer()
+
+    // Frame 1: two agents
+    const agents1 = new Map<string, Agent>([
+      ['a1', makeAgent('a1')],
+      ['a2', makeAgent('a2')],
+    ])
+    layer.update(agents1, null, null, false, 0)
+    expect(layer.getEntry('a1')!.container.visible).toBe(true)
+    expect(layer.getEntry('a2')!.container.visible).toBe(true)
+
+    // Frame 2: only a1 remains
+    const agents2 = new Map<string, Agent>([
+      ['a1', makeAgent('a1')],
+    ])
+    layer.update(agents2, null, null, false, 1)
+    expect(layer.getEntry('a1')!.container.visible).toBe(true)
+    expect(layer.getEntry('a2')!.container.visible).toBe(false)
+  })
+
+  it('pulse ring is visible only for thinking agents', () => {
+    const layer = new AgentsLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1', { state: 'thinking' })],
+      ['a2', makeAgent('a2', { state: 'idle' })],
+    ])
+
+    layer.update(agents, null, null, false, 0)
+
+    expect(layer.getEntry('a1')!.pulseRing.visible).toBe(true)
+    expect(layer.getEntry('a2')!.pulseRing.visible).toBe(false)
+  })
+})

--- a/web/components/agent-visualizer/pixi/agents-layer.ts
+++ b/web/components/agent-visualizer/pixi/agents-layer.ts
@@ -1,0 +1,275 @@
+/**
+ * Agent rendering layer — sprite-based via persistent Pixi Containers.
+ *
+ * Each agent gets a Container holding:
+ *   - A circle sprite for the body (color via tint, sized by agent state).
+ *   - A label sprite from the glyph atlas.
+ *   - A selection ring sprite (visible when selected).
+ *   - A hover halo sprite (visible when hovered).
+ *   - An optional stats overlay sprite (visible when showStats is true).
+ *
+ * State-driven color uses tint changes — no texture re-allocation.
+ * Persistent display objects across frames: same agent set on consecutive
+ * frames does not allocate.
+ *
+ * Follows the same pattern as ParticlesLayer / EdgesLayer: constructor
+ * creates a Container, update() is called once per rAF tick, dispose()
+ * tears down.
+ */
+
+import { Container, Sprite, Graphics } from 'pixi.js'
+import type { Agent } from '@/lib/agent-types'
+import { NODE, ANIM } from '@/lib/agent-types'
+import { AGENT_DRAW, STATS_OVERLAY } from '@/lib/canvas-constants'
+import { getStateColor } from '@/lib/colors'
+import { getCircleTexture } from './pixi-app'
+import { GlyphAtlas } from './glyph-atlas'
+
+/** Persistent state for one agent's display objects. */
+interface AgentEntry {
+  /** Root container for this agent. */
+  container: Container
+  /** Circle body sprite. */
+  body: Sprite
+  /** Selection ring graphics. */
+  selectionRing: Graphics
+  /** Hover halo graphics. */
+  hoverHalo: Graphics
+  /** Name label sprite (from glyph atlas). */
+  labelSprite: Sprite | null
+  /** Stats overlay sprite (from glyph atlas). */
+  statsSprite: Sprite | null
+  /** Active pulse ring (for thinking state animation). */
+  pulseRing: Graphics
+  /** Last-rendered label text (to detect changes). */
+  lastLabelText: string
+  /** Last-rendered label color. */
+  lastLabelColor: string
+  /** Last-rendered stats text. */
+  lastStatsText: string
+  /** Agent id. */
+  agentId: string
+}
+
+/** Parse a CSS hex color string to a numeric tint value. */
+function parseColor(hex: string): number {
+  if (hex.startsWith('#')) {
+    return parseInt(hex.slice(1, 7), 16)
+  }
+  return 0xffffff
+}
+
+/**
+ * Manages the agent rendering layer. Owns a Container that the caller adds
+ * to the Pixi stage. Call `update()` each frame with the current simulation
+ * state to position and style agent sprites.
+ */
+export class AgentsLayer {
+  readonly container: Container
+  private entries = new Map<string, AgentEntry>()
+  private readonly glyphAtlas: GlyphAtlas
+  private readonly bodyTexture = getCircleTexture(16)
+
+  constructor() {
+    this.container = new Container()
+    this.container.label = 'agents'
+    this.glyphAtlas = new GlyphAtlas()
+  }
+
+  /**
+   * Update all agent display objects for the current frame.
+   * Called once per rAF tick from pixi-canvas.tsx.
+   */
+  update(
+    agents: Map<string, Agent>,
+    selectedAgentId: string | null,
+    hoveredAgentId: string | null,
+    showStats: boolean,
+    time: number,
+  ): void {
+    const aliveIds = new Set<string>()
+
+    for (const [id, agent] of agents) {
+      aliveIds.add(id)
+
+      let entry = this.entries.get(id)
+      if (!entry) {
+        entry = this.createEntry(id)
+        this.entries.set(id, entry)
+      }
+
+      const isSelected = id === selectedAgentId
+      const isHovered = id === hoveredAgentId
+      const isWaiting = agent.state === 'waiting_permission'
+      const color = getStateColor(agent.state)
+      const tint = parseColor(color)
+
+      // ── Breathe modulation (matches Canvas2D path) ──────────────────
+      const breathe = isWaiting
+        ? Math.sin(time * AGENT_DRAW.waitingBreatheSpeed) * AGENT_DRAW.waitingBreatheAmp + 1
+        : agent.state === 'thinking'
+          ? Math.sin(time * ANIM.breathe.thinkingSpeed) * ANIM.breathe.thinkingAmp + 1
+          : agent.state === 'idle'
+            ? Math.sin(time * ANIM.breathe.idleSpeed) * ANIM.breathe.idleAmp + 1
+            : 1
+
+      const radius = (agent.isMain ? NODE.radiusMain : NODE.radiusSub) * breathe * agent.scale
+
+      // ── Position ────────────────────────────────────────────────────
+      entry.container.x = agent.x
+      entry.container.y = agent.y
+      entry.container.alpha = agent.opacity
+      entry.container.visible = agent.opacity > 0.01
+
+      // ── Body ────────────────────────────────────────────────────────
+      const bodyScale = radius / 16 // texture radius is 16
+      entry.body.scale.set(bodyScale)
+      entry.body.tint = tint
+
+      // ── Selection ring ──────────────────────────────────────────────
+      entry.selectionRing.visible = isSelected
+      if (isSelected) {
+        entry.selectionRing.clear()
+        entry.selectionRing.circle(0, 0, radius + 4)
+        entry.selectionRing.stroke({ width: 2.5, color: tint, alpha: 0.8 })
+      }
+
+      // ── Hover halo ─────────────────────────────────────────────────
+      entry.hoverHalo.visible = isHovered
+      if (isHovered) {
+        entry.hoverHalo.clear()
+        entry.hoverHalo.circle(0, 0, radius + AGENT_DRAW.glowPadding)
+        entry.hoverHalo.fill({ color: tint, alpha: 0.15 })
+      }
+
+      // ── Pulse ring (thinking state) ────────────────────────────────
+      entry.pulseRing.visible = agent.state === 'thinking'
+      if (agent.state === 'thinking') {
+        const pulseAlpha = 0.15 + Math.sin(time * ANIM.pulseSpeed) * 0.1
+        const pulseRadius = radius + AGENT_DRAW.orbitParticleOffset
+        entry.pulseRing.clear()
+        entry.pulseRing.circle(0, 0, pulseRadius)
+        entry.pulseRing.stroke({ width: 1.5, color: tint, alpha: pulseAlpha })
+      }
+
+      // ── Label ──────────────────────────────────────────────────────
+      const labelColor = isHovered ? '#aaeeff' : '#66ccffcc'
+      const labelText = agent.name
+      if (labelText !== entry.lastLabelText || labelColor !== entry.lastLabelColor) {
+        if (entry.labelSprite) {
+          entry.container.removeChild(entry.labelSprite)
+          entry.labelSprite.destroy()
+        }
+        const glyph = this.glyphAtlas.getGlyph(labelText, labelColor, 10)
+        const sprite = new Sprite(glyph.texture)
+        sprite.anchor.set(0.5, 0)
+        sprite.label = 'label'
+        entry.container.addChild(sprite)
+        entry.labelSprite = sprite
+        entry.lastLabelText = labelText
+        entry.lastLabelColor = labelColor
+      }
+      if (entry.labelSprite) {
+        entry.labelSprite.y = radius + AGENT_DRAW.labelYOffset
+      }
+
+      // ── Stats overlay ──────────────────────────────────────────────
+      if (showStats && agent.state !== 'complete') {
+        const statsText = `${agent.toolCalls} tools · ${agent.timeAlive.toFixed(1)}s`
+        if (statsText !== entry.lastStatsText) {
+          if (entry.statsSprite) {
+            entry.container.removeChild(entry.statsSprite)
+            entry.statsSprite.destroy()
+          }
+          const glyph = this.glyphAtlas.getGlyph(statsText, '#66ccff90', STATS_OVERLAY.fontSize)
+          const sprite = new Sprite(glyph.texture)
+          sprite.anchor.set(0.5, 1)
+          sprite.label = 'stats'
+          entry.container.addChild(sprite)
+          entry.statsSprite = sprite
+          entry.lastStatsText = statsText
+        }
+        if (entry.statsSprite) {
+          entry.statsSprite.y = -(radius + STATS_OVERLAY.yOffset)
+          entry.statsSprite.visible = true
+        }
+      } else if (entry.statsSprite) {
+        entry.statsSprite.visible = false
+      }
+    }
+
+    // Hide entries for agents that no longer exist
+    for (const [id, entry] of this.entries) {
+      if (!aliveIds.has(id)) {
+        entry.container.visible = false
+      }
+    }
+  }
+
+  /** Release GPU resources and remove all display objects. */
+  dispose(): void {
+    for (const entry of this.entries.values()) {
+      entry.container.destroy({ children: true })
+    }
+    this.entries.clear()
+    this.glyphAtlas.dispose()
+    this.container.destroy({ children: true })
+  }
+
+  /** Number of agent entries — useful for tests. */
+  get entryCount(): number {
+    return this.entries.size
+  }
+
+  /** Retrieve an entry by agent id — useful for tests. */
+  getEntry(agentId: string): AgentEntry | undefined {
+    return this.entries.get(agentId)
+  }
+
+  // ── Internal ──────────────────────────────────────────────────────────
+
+  private createEntry(agentId: string): AgentEntry {
+    const container = new Container()
+    container.label = `agent-${agentId}`
+
+    // Body circle
+    const body = new Sprite(this.bodyTexture)
+    body.anchor.set(0.5)
+    body.label = 'body'
+    container.addChild(body)
+
+    // Selection ring
+    const selectionRing = new Graphics()
+    selectionRing.label = 'selection-ring'
+    selectionRing.visible = false
+    container.addChild(selectionRing)
+
+    // Hover halo
+    const hoverHalo = new Graphics()
+    hoverHalo.label = 'hover-halo'
+    hoverHalo.visible = false
+    container.addChild(hoverHalo)
+
+    // Pulse ring (thinking animation)
+    const pulseRing = new Graphics()
+    pulseRing.label = 'pulse-ring'
+    pulseRing.visible = false
+    container.addChild(pulseRing)
+
+    this.container.addChild(container)
+
+    return {
+      container,
+      body,
+      selectionRing,
+      hoverHalo,
+      labelSprite: null,
+      statsSprite: null,
+      pulseRing,
+      lastLabelText: '',
+      lastLabelColor: '',
+      lastStatsText: '',
+      agentId,
+    }
+  }
+}

--- a/web/components/agent-visualizer/pixi/glyph-atlas.test.ts
+++ b/web/components/agent-visualizer/pixi/glyph-atlas.test.ts
@@ -23,7 +23,7 @@ const origCreateElement = document.createElement.bind(document)
 vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
   const el = origCreateElement(tag)
   if (tag === 'canvas') {
-    (el as HTMLCanvasElement).getContext = (() => mockCtx) as unknown as typeof el.getContext
+    (el as HTMLCanvasElement).getContext = (() => mockCtx) as unknown as HTMLCanvasElement['getContext']
   }
   return el
 })

--- a/web/components/agent-visualizer/pixi/glyph-atlas.test.ts
+++ b/web/components/agent-visualizer/pixi/glyph-atlas.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for GlyphAtlas — validates caching, uniqueness, and disposal.
+ *
+ * Run with: cd web && pnpm test
+ *
+ * Mocks pixi.js to avoid needing a real GPU context.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ─── Mock HTMLCanvasElement.getContext for jsdom ─────────────────────────
+// jsdom doesn't implement canvas 2D context. We provide a minimal stub.
+
+const mockCtx = {
+  font: '',
+  textBaseline: '',
+  fillStyle: '',
+  measureText: (text: string) => ({ width: text.length * 6 }),
+  fillText: vi.fn(),
+}
+
+const origCreateElement = document.createElement.bind(document)
+vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+  const el = origCreateElement(tag)
+  if (tag === 'canvas') {
+    (el as HTMLCanvasElement).getContext = (() => mockCtx) as unknown as typeof el.getContext
+  }
+  return el
+})
+
+// ─── Mock pixi.js before importing GlyphAtlas ────────────────────────────
+
+let textureIdCounter = 0
+
+vi.mock('pixi.js', () => {
+  class MockRectangle {
+    x: number; y: number; width: number; height: number
+    constructor(x = 0, y = 0, w = 0, h = 0) {
+      this.x = x; this.y = y; this.width = w; this.height = h
+    }
+  }
+
+  class MockTextureSource {
+    _id: number
+    constructor() { this._id = textureIdCounter++ }
+  }
+
+  class MockTexture {
+    source: MockTextureSource
+    frame: MockRectangle
+    _destroyed = false
+    constructor(opts?: { source?: MockTextureSource; frame?: MockRectangle }) {
+      this.source = opts?.source ?? new MockTextureSource()
+      this.frame = opts?.frame ?? new MockRectangle()
+    }
+    destroy() { this._destroyed = true }
+    static from(_opts: unknown): MockTexture {
+      return new MockTexture()
+    }
+  }
+
+  return {
+    Texture: MockTexture,
+    Rectangle: MockRectangle,
+  }
+})
+
+// ─── Import after mocks ──────────────────────────────────────────────────
+
+import { GlyphAtlas } from './glyph-atlas'
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+
+describe('GlyphAtlas', () => {
+  beforeEach(() => {
+    textureIdCounter = 0
+  })
+
+  it('same (text, color) returns the same texture reference', () => {
+    const atlas = new GlyphAtlas()
+    const a = atlas.getGlyph('hello', '#ff0000')
+    const b = atlas.getGlyph('hello', '#ff0000')
+
+    expect(a).toBe(b)
+    expect(atlas.size).toBe(1)
+
+    atlas.dispose()
+  })
+
+  it('different colors return different texture descriptors', () => {
+    const atlas = new GlyphAtlas()
+    const a = atlas.getGlyph('hello', '#ff0000')
+    const b = atlas.getGlyph('hello', '#00ff00')
+
+    expect(a).not.toBe(b)
+    expect(a.texture).not.toBe(b.texture)
+    expect(atlas.size).toBe(2)
+
+    atlas.dispose()
+  })
+
+  it('different font sizes return different descriptors', () => {
+    const atlas = new GlyphAtlas()
+    const a = atlas.getGlyph('hello', '#ff0000', 10)
+    const b = atlas.getGlyph('hello', '#ff0000', 14)
+
+    expect(a).not.toBe(b)
+    expect(atlas.size).toBe(2)
+
+    atlas.dispose()
+  })
+
+  it('many entries do not crash', () => {
+    const atlas = new GlyphAtlas()
+
+    for (let i = 0; i < 200; i++) {
+      const glyph = atlas.getGlyph(`text-${i}`, `#${(i * 1234).toString(16).padStart(6, '0').slice(0, 6)}`)
+      expect(glyph).toBeDefined()
+      expect(glyph.width).toBeGreaterThan(0)
+      expect(glyph.height).toBeGreaterThan(0)
+    }
+
+    expect(atlas.size).toBe(200)
+
+    atlas.dispose()
+  })
+
+  it('dispose frees all resources', () => {
+    const atlas = new GlyphAtlas()
+    atlas.getGlyph('a', '#ff0000')
+    atlas.getGlyph('b', '#00ff00')
+    atlas.getGlyph('c', '#0000ff')
+
+    expect(atlas.size).toBe(3)
+    expect(atlas.pageCount).toBeGreaterThan(0)
+
+    atlas.dispose()
+
+    expect(atlas.size).toBe(0)
+    expect(atlas.pageCount).toBe(0)
+  })
+
+  it('returns descriptors with positive dimensions', () => {
+    const atlas = new GlyphAtlas()
+    const glyph = atlas.getGlyph('test string', '#ffffff', 12)
+
+    expect(glyph.width).toBeGreaterThan(0)
+    expect(glyph.height).toBeGreaterThan(0)
+    expect(glyph.texture).toBeDefined()
+
+    atlas.dispose()
+  })
+})

--- a/web/components/agent-visualizer/pixi/glyph-atlas.ts
+++ b/web/components/agent-visualizer/pixi/glyph-atlas.ts
@@ -1,0 +1,170 @@
+/**
+ * GlyphAtlas — bakes monospace text strings into a texture atlas for GPU blitting.
+ *
+ * Design:
+ *   - Cache key: `${text}|${color}|${fontSize}`.
+ *   - Allocation: row-packed backing canvases. When a row can't fit the next
+ *     glyph, a new row starts. When the canvas is full, a new backing canvas
+ *     is allocated (no bin-packing for v1).
+ *   - Returns Pixi `Texture` sub-regions referencing the backing BaseTexture.
+ *
+ * Font: `'SF Mono', 'Fira Code', monospace` to match the Canvas2D path.
+ */
+
+import { Texture, Rectangle } from 'pixi.js'
+
+/** Descriptor returned by `getGlyph`. */
+export interface GlyphDescriptor {
+  texture: Texture
+  width: number
+  height: number
+}
+
+/** Internal: one backing canvas and its current allocation cursor. */
+interface AtlasPage {
+  canvas: HTMLCanvasElement
+  ctx: CanvasRenderingContext2D
+  /** Pixi base texture wrapping this canvas. */
+  baseTexture: Texture
+  /** Current X cursor within the active row. */
+  cursorX: number
+  /** Current Y cursor (top of the active row). */
+  cursorY: number
+  /** Tallest glyph in the current row. */
+  rowHeight: number
+}
+
+const ATLAS_SIZE = 1024
+const ATLAS_PADDING = 2
+const DEFAULT_FONT_SIZE = 10
+const FONT_FAMILY = "'SF Mono', 'Fira Code', monospace"
+
+export class GlyphAtlas {
+  private cache = new Map<string, GlyphDescriptor>()
+  private pages: AtlasPage[] = []
+
+  /** Look up or render a glyph and return its texture descriptor. */
+  getGlyph(text: string, color: string, fontSize = DEFAULT_FONT_SIZE): GlyphDescriptor {
+    const key = `${text}|${color}|${fontSize}`
+    const cached = this.cache.get(key)
+    if (cached) return cached
+
+    // Measure the text
+    const font = `${fontSize}px ${FONT_FAMILY}`
+    const measuringCtx = this.getMeasuringContext()
+    measuringCtx.font = font
+    const metrics = measuringCtx.measureText(text)
+    const w = Math.ceil(metrics.width) + ATLAS_PADDING * 2
+    const h = Math.ceil(fontSize * 1.4) + ATLAS_PADDING * 2
+
+    // Find or create a page with room
+    const page = this.findPageWithRoom(w, h)
+
+    // Render text into the page
+    const x = page.cursorX
+    const y = page.cursorY
+    page.ctx.font = font
+    page.ctx.textBaseline = 'top'
+    page.ctx.fillStyle = color
+    page.ctx.fillText(text, x + ATLAS_PADDING, y + ATLAS_PADDING)
+
+    // Advance cursor
+    page.cursorX += w
+    page.rowHeight = Math.max(page.rowHeight, h)
+
+    // Build a Texture sub-region
+    const frame = new Rectangle(x, y, w, h)
+    // Pixi v8: Texture constructor takes a TextureSource + a TextureLayout.
+    // The simplest sub-region approach is Texture(source, { frame }).
+    const texture = new Texture({
+      source: page.baseTexture.source,
+      frame,
+    })
+
+    const descriptor: GlyphDescriptor = { texture, width: w, height: h }
+    this.cache.set(key, descriptor)
+    return descriptor
+  }
+
+  /** Free all backing canvases and Pixi textures. */
+  dispose(): void {
+    for (const desc of this.cache.values()) {
+      desc.texture.destroy()
+    }
+    this.cache.clear()
+    for (const page of this.pages) {
+      page.baseTexture.destroy(true)
+    }
+    this.pages.length = 0
+  }
+
+  /** Number of cached glyph entries (useful for tests). */
+  get size(): number {
+    return this.cache.size
+  }
+
+  /** Number of atlas pages allocated (useful for tests). */
+  get pageCount(): number {
+    return this.pages.length
+  }
+
+  // ── Internal ──────────────────────────────────────────────────────────
+
+  private measuringCanvas: HTMLCanvasElement | null = null
+  private measuringCtx: CanvasRenderingContext2D | null = null
+
+  private getMeasuringContext(): CanvasRenderingContext2D {
+    if (!this.measuringCtx) {
+      this.measuringCanvas = document.createElement('canvas')
+      this.measuringCanvas.width = 1
+      this.measuringCanvas.height = 1
+      this.measuringCtx = this.measuringCanvas.getContext('2d')!
+    }
+    return this.measuringCtx
+  }
+
+  private findPageWithRoom(w: number, h: number): AtlasPage {
+    // Try the last page first (most likely to have room)
+    if (this.pages.length > 0) {
+      const page = this.pages[this.pages.length - 1]
+      if (this.canFit(page, w, h)) return page
+    }
+    // Allocate a new page
+    return this.allocatePage()
+  }
+
+  private canFit(page: AtlasPage, w: number, h: number): boolean {
+    // Fits in current row?
+    if (page.cursorX + w <= ATLAS_SIZE) return true
+    // Start a new row?
+    const newRowY = page.cursorY + page.rowHeight
+    if (newRowY + h <= ATLAS_SIZE) {
+      // Advance to new row
+      page.cursorX = 0
+      page.cursorY = newRowY
+      page.rowHeight = 0
+      return true
+    }
+    return false
+  }
+
+  private allocatePage(): AtlasPage {
+    const canvas = document.createElement('canvas')
+    canvas.width = ATLAS_SIZE
+    canvas.height = ATLAS_SIZE
+    const ctx = canvas.getContext('2d')!
+
+    const baseTexture = Texture.from({ resource: canvas, alphaMode: 'premultiply-alpha-on-upload' })
+
+    const page: AtlasPage = {
+      canvas,
+      ctx,
+      baseTexture,
+      cursorX: 0,
+      cursorY: 0,
+      rowHeight: 0,
+    }
+    this.pages.push(page)
+    return page
+  }
+}

--- a/web/components/agent-visualizer/pixi/pixi-canvas.tsx
+++ b/web/components/agent-visualizer/pixi/pixi-canvas.tsx
@@ -18,6 +18,7 @@ import type { SimulationState } from '@/hooks/simulation/types'
 import { useCanvasCamera } from '@/hooks/use-canvas-camera'
 import { useCanvasInteraction } from '@/hooks/use-canvas-interaction'
 import { createPixiApp, disposeTextureCache } from './pixi-app'
+import { AgentsLayer } from './agents-layer'
 import { EdgesLayer } from './edges-layer'
 import { ParticlesLayer } from './particles-layer'
 import { applyCameraTransform } from './camera'
@@ -47,9 +48,7 @@ interface CanvasProps {
 export function PixiCanvas({
   simulationRef,
   selectedAgentId,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   hoveredAgentId,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   showStats,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   showHexGrid,
@@ -71,6 +70,7 @@ export function PixiCanvas({
 }: CanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const appRef = useRef<Application | null>(null)
+  const agentsLayerRef = useRef<AgentsLayer | null>(null)
   const edgesLayerRef = useRef<EdgesLayer | null>(null)
   const particlesLayerRef = useRef<ParticlesLayer | null>(null)
   const worldRef = useRef<Container | null>(null)
@@ -228,12 +228,17 @@ export function PixiCanvas({
       app.stage.addChild(world)
       worldRef.current = world
 
-      // Edges layer (behind particles in z-order, matching Canvas2D draw order)
+      // Edges layer (behind agents in z-order, matching Canvas2D draw order)
       const edgesLayer = new EdgesLayer()
       world.addChild(edgesLayer.container)
       edgesLayerRef.current = edgesLayer
 
-      // Particles layer (functional)
+      // Agents layer (above edges, below particles)
+      const agentsLayer = new AgentsLayer()
+      world.addChild(agentsLayer.container)
+      agentsLayerRef.current = agentsLayer
+
+      // Particles layer (topmost world-space layer)
       const particlesLayer = new ParticlesLayer()
       world.addChild(particlesLayer.container)
       particlesLayerRef.current = particlesLayer
@@ -268,12 +273,21 @@ export function PixiCanvas({
         // Apply camera transform to the world container
         applyCameraTransform(world, transformRef.current)
 
-        // Update edges layer (drawn behind particles)
+        // Update edges layer (drawn behind agents)
         edgesLayer.update(
           s.edges,
           s.particles,
           s.agents,
           s.toolCalls,
+          timeRef.current,
+        )
+
+        // Update agents layer (above edges, below particles)
+        agentsLayer.update(
+          s.agents,
+          selectedAgentId,
+          hoveredAgentId,
+          showStats,
           timeRef.current,
         )
 
@@ -295,6 +309,10 @@ export function PixiCanvas({
     return () => {
       destroyed = true
       if (animRef.current) cancelAnimationFrame(animRef.current)
+      if (agentsLayerRef.current) {
+        agentsLayerRef.current.dispose()
+        agentsLayerRef.current = null
+      }
       if (edgesLayerRef.current) {
         edgesLayerRef.current.dispose()
         edgesLayerRef.current = null


### PR DESCRIPTION
## Summary

- **GlyphAtlas** (`web/components/agent-visualizer/pixi/glyph-atlas.ts`): Row-packed texture atlas that bakes monospace text strings into GPU textures keyed by `(text, color, fontSize)`. Persistent for the renderer lifetime — no per-frame `fillText` calls. Foundation for #13 and #14 as well.
- **AgentsLayer** (`web/components/agent-visualizer/pixi/agents-layer.ts`): One `Container` per agent holding body sprite (tint-driven state color), selection ring, hover halo, pulse ring (thinking animation), glyph-atlas label, and optional stats overlay. Persistent display objects across frames — same agent set on consecutive frames does not allocate.
- **Wiring** (`web/components/agent-visualizer/pixi/pixi-canvas.tsx`): AgentsLayer mounted between edges and particles in z-order. `selectedAgentId`, `hoveredAgentId`, `showStats` passed through. Disposed on unmount.

## Test plan

- [x] `cd web && pnpm typecheck` — zero errors
- [x] `cd web && pnpm test` — 9 files, 72 tests pass (14 new: 6 glyph-atlas + 8 agents-layer)
- [x] `cd web && pnpm build` — builds successfully
- [x] `cd web && pnpm build:webview` — builds successfully
- [x] `cd extension && pnpm test` — 28 tests pass (no regressions)
- [ ] **Manual**: `pnpm dev`, open `http://localhost:3000?renderer=pixi`, run `pnpm sim subagents` — verify agents render with:
  - Correct positions and state-driven colors (blue=thinking, amber=tool_calling, green=complete)
  - Agent name labels below each node
  - Selection ring when clicking an agent
  - Hover halo when mousing over an agent
  - Stats overlay when `showStats` is enabled
  - Breathing/pulse animation on thinking agents
- [ ] **Manual**: compare side-by-side with `http://localhost:3000` (Canvas2D) — visual parity for agent positions, colors, labels
- [ ] **Manual**: open `http://localhost:3000` (no flag) — verify default Canvas2D path is unchanged

## Notes

- Manual verification at `?renderer=pixi` is required for visual parity — headless tests cover logic only
- Hit-detection for agent click/hover in the Pixi path depends on #27 (coordinate adapter); this PR renders agents but click targeting still uses the Canvas2D hit-test path via shared hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)