### PR TITLE
Fix: make dev relay reachable over LAN / Tailscale / SSH-forward

### DIFF
--- a/scripts/dev-relay.ts
+++ b/scripts/dev-relay.ts
@@ -40,8 +40,12 @@ async function main() {
     res.end('Agent Flow Dev Relay')
   })
 
-  server.listen(DEFAULT_RELAY_PORT, '127.0.0.1', () => {
-    console.log(`\nSSE relay on http://127.0.0.1:${DEFAULT_RELAY_PORT}/events`)
+  // Dev-only: bind to all interfaces so the relay is reachable from a
+  // browser loading the Next dev server over LAN / Tailscale / SSH-forward.
+  // Override with AGENT_FLOW_DEV_RELAY_HOST=127.0.0.1 to lock to loopback.
+  const host = process.env.AGENT_FLOW_DEV_RELAY_HOST || '0.0.0.0'
+  server.listen(DEFAULT_RELAY_PORT, host, () => {
+    console.log(`\nSSE relay on http://${host}:${DEFAULT_RELAY_PORT}/events`)
     console.log('Ready! Events will appear in the web app.')
   })
 

--- a/web/hooks/use-vscode-bridge.ts
+++ b/web/hooks/use-vscode-bridge.ts
@@ -102,7 +102,12 @@ export function useVSCodeBridge(): BridgeHookResult {
     if (!isStandalone && (process.env.NODE_ENV !== 'development' || process.env.NEXT_PUBLIC_DEMO !== '0')) return
 
     const relayPort = process.env.NEXT_PUBLIC_RELAY_PORT || ''
-    const es = new EventSource(relayPort ? `http://127.0.0.1:${relayPort}/events` : '/events')
+    // Use the page's hostname so the SSE connection works whether the user
+    // is loading Next over localhost, a LAN IP, or a Tailscale/SSH-forward
+    // hostname. Falls back to '/events' (relative) when no port is set —
+    // standalone-app mode serves the relay from the same origin.
+    const host = typeof window !== 'undefined' ? window.location.hostname : '127.0.0.1'
+    const es = new EventSource(relayPort ? `http://${host}:${relayPort}/events` : '/events')
 
     es.onopen = () => {
       setConnectionStatus('connected')


### PR DESCRIPTION
## What

Two-line fix that lets the dev relay accept SSE connections from a browser loading Next over a non-loopback hostname (LAN IP, Tailscale, SSH-forward, etc).

## Why

Today:
- \`scripts/dev-relay.ts:43\` binds to \`'127.0.0.1'\`.
- \`web/hooks/use-vscode-bridge.ts:105\` constructs the SSE URL as \`http://127.0.0.1:\${relayPort}/events\`.

Both hardcode loopback, so the only working browser is one running on the same machine over \`localhost\`. Loading the Next dev server (which already binds to \`*:3000\`) from any other host hits two consecutive failures: the browser tries \`http://127.0.0.1:3001/events\` (which on the user's machine isn't running anything), and even if you fix the URL, the relay only listens on the dev machine's loopback interface anyway.

## Fix

1. **Server**: \`scripts/dev-relay.ts\` reads \`AGENT_FLOW_DEV_RELAY_HOST\` env var, defaulting to \`'0.0.0.0'\` (was \`'127.0.0.1'\`). Override-back to loopback if needed.
2. **Client**: \`web/hooks/use-vscode-bridge.ts\` builds the SSE URL from \`window.location.hostname\` instead of \`127.0.0.1\`.

Standalone-app mode is unaffected — it uses the relative \`/events\` path when \`NEXT_PUBLIC_RELAY_PORT\` is empty.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test\` (web) — 72/72
- [x] \`pnpm build\` — clean
- [x] \`pnpm test\` (extension) — 28/28
- [ ] Manual: \`pnpm dev\`, load Next from a LAN IP, verify SSE connects and sessions appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)