### PR TITLE
Feat: page-wide FPS indicator in top bar

### DIFF
--- a/web/components/agent-visualizer/fps-indicator.tsx
+++ b/web/components/agent-visualizer/fps-indicator.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { COLORS } from '@/lib/colors'
+
+const SAMPLE_WINDOW_MS = 1000
+const UPDATE_INTERVAL_MS = 500
+
+const FPS_GOOD = 55
+const FPS_CAUTION = 30
+
+function colorFor(fps: number): string {
+  if (fps >= FPS_GOOD) return COLORS.complete
+  if (fps >= FPS_CAUTION) return COLORS.tool
+  return COLORS.error
+}
+
+export function FPSIndicator() {
+  const [fps, setFps] = useState(0)
+  const framesRef = useRef<number[]>([])
+  const lastUpdateRef = useRef(0)
+  const rafRef = useRef(0)
+
+  useEffect(() => {
+    const tick = (timestamp: number) => {
+      const frames = framesRef.current
+      frames.push(timestamp)
+      const cutoff = timestamp - SAMPLE_WINDOW_MS
+      while (frames.length > 0 && frames[0] < cutoff) frames.shift()
+
+      if (timestamp - lastUpdateRef.current >= UPDATE_INTERVAL_MS) {
+        lastUpdateRef.current = timestamp
+        setFps(frames.length)
+      }
+      rafRef.current = requestAnimationFrame(tick)
+    }
+    rafRef.current = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(rafRef.current)
+  }, [])
+
+  const color = colorFor(fps)
+  return (
+    <div
+      title="Browser frame rate (rAF). Page-wide; reflects overall render budget."
+      className="font-mono"
+      style={{
+        height: 26,
+        padding: '0 10px',
+        fontSize: 11,
+        lineHeight: '26px',
+        background: 'rgba(100, 200, 255, 0.06)',
+        border: '1px solid rgba(100, 200, 255, 0.18)',
+        borderRadius: 4,
+        userSelect: 'none',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        color: COLORS.textPrimary,
+      }}
+    >
+      <span
+        style={{
+          width: 8, height: 8, borderRadius: '50%',
+          background: color, boxShadow: `0 0 4px ${color}`,
+        }}
+      />
+      <span style={{ color }}>{fps}</span>
+      <span style={{ color: COLORS.textMuted, fontSize: 10 }}>fps</span>
+    </div>
+  )
+}

--- a/web/components/agent-visualizer/top-bar.tsx
+++ b/web/components/agent-visualizer/top-bar.tsx
@@ -7,6 +7,7 @@ import { formatTokens } from "@/lib/utils"
 import { agentCost } from "./canvas/draw-cost"
 import { SessionTabs } from "./session-tabs"
 import { FloatingPanel } from "./floating-panel"
+import { FPSIndicator } from "./fps-indicator"
 import { usePanelLayout } from "@/hooks/use-panel-layout"
 import type { WorkspaceFilterAPI } from "@/hooks/use-workspace-filter"
 import type { SessionInfo, ConnectionStatus } from "@/lib/bridge-types"
@@ -228,6 +229,7 @@ export const TopBar = memo(function TopBar({
 
         {/* Right-side info/controls */}
         <div className="flex items-center gap-4 flex-shrink-0" style={{ color: COLORS.textMuted }}>
+          <FPSIndicator />
           {isVSCode && <ConnectionIndicator status={connectionStatus} />}
 
           {/* Panel toggle group */}


### PR DESCRIPTION
Small FPS pill in the right side of the top bar.

- Samples \`requestAnimationFrame\` timestamps over a 1s rolling window.
- Refreshes the visible number every 500ms (not every frame — avoids self-induced re-render churn).
- Color-coded: green ≥55, amber ≥30, red <30.

Page-wide rather than per-canvas. With the shared simulation rAF (post-#25), every canvas renders in lockstep, so per-canvas FPS would just be N copies of the same number. The thing that differs per canvas is *frame cost* (ms), which the existing \`?perf\` overlay already shows.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` 72/72
- [x] \`pnpm build\` clean
- [x] \`pnpm build:webview\` clean
- [ ] Manual: pill renders in top bar, number animates and color tracks. Compare against \`baseline/fps-indicator\` branch (built from pre-PR-1 fork point) for perf comparison.

## Related

A parallel branch \`baseline/fps-indicator\` cherry-picks this same indicator onto the pre-PR-1 fork point so the two versions can be loaded side-by-side and compared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)