### PR TITLE
perf: Pixi follow-ups — visibility hook + per-pixel hit-test (closes #33, closes #34)

### DIFF
--- a/web/components/agent-visualizer/canvas.tsx
+++ b/web/components/agent-visualizer/canvas.tsx
@@ -23,6 +23,7 @@ import {
 } from './canvas/'
 import { useCanvasCamera } from '@/hooks/use-canvas-camera'
 import { useCanvasInteraction } from '@/hooks/use-canvas-interaction'
+import { useCanvasVisibility } from '@/hooks/use-canvas-visibility'
 import { createCanvas2DHitTestAdapter } from '@/hooks/hit-test-adapters'
 import { useSimulationManager } from './simulation-manager-provider'
 
@@ -85,13 +86,8 @@ export function AgentCanvas({
   const toolStatesBRef = useRef<Map<string, string>>(new Map())
   const stateMapsUseARef = useRef(true)
 
-  // IntersectionObserver visibility gating — when true, the canvas is in the
-  // viewport and the render rAF should draw. When false, we skip drawing to
-  // save GPU work while the simulation sub-state keeps ticking.
-  const visibleRef = useRef(true)
-  // Flag: when the canvas re-enters the viewport, force one immediate redraw
-  // to catch up with simulation changes that happened while off-screen.
-  const needsCatchUpRef = useRef(false)
+  // Visibility gating: IntersectionObserver + document.visibilityState
+  const { visibleRef, needsCatchUpRef } = useCanvasVisibility(containerRef, pauseWhenOffscreen)
 
   // Rate-limited error logging for the draw loop (avoid flooding console)
   const lastDrawErrorRef = useRef(0)
@@ -187,29 +183,6 @@ export function AgentCanvas({
     return () => observer.disconnect()
   }, [])
 
-  // ─── IntersectionObserver: pause render rAF when off-screen ─────────────
-  useEffect(() => {
-    if (!pauseWhenOffscreen) {
-      visibleRef.current = true
-      return
-    }
-    const el = containerRef.current
-    if (!el) return
-    const observer = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          const wasVisible = visibleRef.current
-          visibleRef.current = entry.isIntersecting
-          if (!wasVisible && entry.isIntersecting) {
-            needsCatchUpRef.current = true
-          }
-        }
-      },
-      { threshold: 0 },
-    )
-    observer.observe(el)
-    return () => observer.disconnect()
-  }, [pauseWhenOffscreen])
 
   // ─── Detect state changes → spawn effects ──────────────────────────────
 

--- a/web/components/agent-visualizer/pixi/agents-layer.test.ts
+++ b/web/components/agent-visualizer/pixi/agents-layer.test.ts
@@ -19,6 +19,7 @@ vi.mock('pixi.js', () => {
     y = 0
     alpha = 1
     visible = true
+    eventMode = 'auto'
     addChild(child: unknown) { this.children.push(child) }
     removeChild(child: unknown) {
       const idx = this.children.indexOf(child)
@@ -268,6 +269,18 @@ describe('AgentsLayer', () => {
     layer.update(agents2, null, null, false, 1)
     expect(layer.getEntry('a1')!.container.visible).toBe(true)
     expect(layer.getEntry('a2')!.container.visible).toBe(false)
+  })
+
+  it('created entries have eventMode set to static', () => {
+    const layer = new AgentsLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1')],
+    ])
+
+    layer.update(agents, null, null, false, 0)
+
+    const entry = layer.getEntry('a1')!
+    expect((entry.container as unknown as { eventMode: string }).eventMode).toBe('static')
   })
 
   it('pulse ring is visible only for thinking agents', () => {

--- a/web/components/agent-visualizer/pixi/agents-layer.ts
+++ b/web/components/agent-visualizer/pixi/agents-layer.ts
@@ -231,6 +231,7 @@ export class AgentsLayer {
   private createEntry(agentId: string): AgentEntry {
     const container = new Container()
     container.label = `agent-${agentId}`
+    container.eventMode = 'static'
 
     // Body circle
     const body = new Sprite(this.bodyTexture)

--- a/web/components/agent-visualizer/pixi/bubbles-layer.test.ts
+++ b/web/components/agent-visualizer/pixi/bubbles-layer.test.ts
@@ -17,6 +17,7 @@ vi.mock('pixi.js', () => {
     y = 0
     alpha = 1
     visible = true
+    eventMode = 'auto'
     addChild(child: unknown) { this.children.push(child) }
     removeChild(child: unknown) {
       const idx = this.children.indexOf(child)
@@ -190,6 +191,22 @@ describe('BubblesLayer', () => {
 
     // Both should be active and at different Y positions
     expect(layer.activeCount).toBe(2)
+  })
+
+  it('active bubble entries have eventMode=static and label=bubble-{agentId}', () => {
+    const layer = new BubblesLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1', [makeBubble(0)])],
+    ])
+
+    layer.update(agents, 2)
+
+    // Access active entries via the pool (container children of the root)
+    const bubbleContainers = (layer.container.children as Array<{ label: string; eventMode: string }>)
+      .filter(c => c.label.startsWith('bubble-'))
+    expect(bubbleContainers.length).toBeGreaterThan(0)
+    expect(bubbleContainers[0].eventMode).toBe('static')
+    expect(bubbleContainers[0].label).toBe('bubble-a1')
   })
 
   it('dispose cleans up all entries', () => {

--- a/web/components/agent-visualizer/pixi/bubbles-layer.ts
+++ b/web/components/agent-visualizer/pixi/bubbles-layer.ts
@@ -137,6 +137,8 @@ export class BubblesLayer {
           entry = this.pool.free.pop() || this.createEntry()
           this.pool.active.set(key, entry)
           entry.container.visible = true
+          entry.container.label = `bubble-${agent.id}`
+          entry.container.eventMode = 'static'
         }
 
         // ── Position + alpha ────────────────────────────────────────

--- a/web/components/agent-visualizer/pixi/pixi-app.test.ts
+++ b/web/components/agent-visualizer/pixi/pixi-app.test.ts
@@ -99,9 +99,18 @@ vi.mock('pixi.js', () => {
     }
   }
 
+  class MockEventBoundary {
+    rootTarget: unknown
+    constructor(root: unknown) {
+      this.rootTarget = root
+    }
+    hitTest() { return null }
+  }
+
   return {
     Application: MockApplication,
     Container: MockContainer,
+    EventBoundary: MockEventBoundary,
     Texture: MockTexture,
     RenderTexture: MockRenderTexture,
     Rectangle: MockRectangle,
@@ -115,9 +124,12 @@ import {
   releaseSharedRenderer,
   registerViewport,
   deregisterViewport,
+  setViewportBoundaryRoot,
+  getViewportBoundary,
   getViewportCount,
   isSharedRendererActive,
 } from './pixi-app'
+import { Container } from 'pixi.js'
 
 // ─── Tests ───────────────────────────────────────────────────────────────
 
@@ -221,6 +233,40 @@ describe('Shared Pixi Renderer', () => {
     // New instance — not the same object
     expect(app2).not.toBe(app1)
     expect(appInstanceCount).toBe(2)
+
+    releaseSharedRenderer()
+  })
+
+  it('setViewportBoundaryRoot creates an EventBoundary on the viewport', async () => {
+    await acquireSharedRenderer()
+    const vp = registerViewport('vp-boundary')
+
+    // Initially no boundary
+    expect(vp.boundary).toBeNull()
+
+    // Set boundary root
+    const world = new Container()
+    setViewportBoundaryRoot('vp-boundary', world)
+
+    expect(vp.boundary).not.toBeNull()
+    expect((vp.boundary as unknown as { rootTarget: unknown }).rootTarget).toBe(world)
+
+    // getViewportBoundary accessor works
+    expect(getViewportBoundary('vp-boundary')).toBe(vp.boundary)
+
+    deregisterViewport('vp-boundary')
+    releaseSharedRenderer()
+  })
+
+  it('deregisterViewport nulls out the boundary', async () => {
+    await acquireSharedRenderer()
+    const vp = registerViewport('vp-null')
+    const world = new Container()
+    setViewportBoundaryRoot('vp-null', world)
+    expect(vp.boundary).not.toBeNull()
+
+    deregisterViewport('vp-null')
+    expect(vp.boundary).toBeNull()
 
     releaseSharedRenderer()
   })

--- a/web/components/agent-visualizer/pixi/pixi-app.ts
+++ b/web/components/agent-visualizer/pixi/pixi-app.ts
@@ -17,7 +17,7 @@
  * calls sharedRenderer.renderViewport() for its viewport id.
  */
 
-import { Application, Container, RenderTexture, Texture } from 'pixi.js'
+import { Application, Container, EventBoundary, RenderTexture, Texture } from 'pixi.js'
 
 // ─── Viewport registry ─────────────────────────────────────────────────────
 
@@ -36,6 +36,8 @@ export interface Viewport {
   /** Current viewport dimensions in CSS pixels. */
   width: number
   height: number
+  /** EventBoundary for per-pixel hit-testing against this viewport's world container. */
+  boundary: EventBoundary | null
 }
 
 /** Singleton state for the shared renderer. */
@@ -144,9 +146,30 @@ export function registerViewport(id: string): Viewport {
     ctx: null,
     width: 0,
     height: 0,
+    boundary: null,
   }
   shared.viewports.set(id, viewport)
   return viewport
+}
+
+/**
+ * Set the EventBoundary root for a viewport. Call after building the world
+ * container so hit-tests route through the correct scene-graph subtree.
+ */
+export function setViewportBoundaryRoot(id: string, root: Container): void {
+  if (!shared) return
+  const vp = shared.viewports.get(id)
+  if (!vp) return
+  vp.boundary = new EventBoundary(root)
+}
+
+/**
+ * Retrieve the EventBoundary for a viewport (for external hit-testing).
+ */
+export function getViewportBoundary(id: string): EventBoundary | null {
+  if (!shared) return null
+  const vp = shared.viewports.get(id)
+  return vp?.boundary ?? null
 }
 
 /**
@@ -161,6 +184,7 @@ export function deregisterViewport(id: string): void {
     vp.renderTexture.destroy(true)
     vp.renderTexture = null
   }
+  vp.boundary = null
   vp.stage.destroy({ children: true })
   shared.viewports.delete(id)
 }

--- a/web/components/agent-visualizer/pixi/pixi-canvas.tsx
+++ b/web/components/agent-visualizer/pixi/pixi-canvas.tsx
@@ -18,10 +18,11 @@
  */
 
 import { useRef, useEffect, useState, useCallback, useMemo, useId } from 'react'
-import { Container } from 'pixi.js'
+import { Container, EventBoundary } from 'pixi.js'
 import type { SimulationState } from '@/hooks/simulation/types'
 import { useCanvasCamera } from '@/hooks/use-canvas-camera'
 import { useCanvasInteraction } from '@/hooks/use-canvas-interaction'
+import { useCanvasVisibility } from '@/hooks/use-canvas-visibility'
 import { createPixiHitTestAdapter } from '@/hooks/hit-test-adapters'
 import {
   acquireSharedRenderer,
@@ -31,6 +32,7 @@ import {
   bindViewportCanvas,
   resizeViewport,
   renderViewport,
+  setViewportBoundaryRoot,
   disposeTextureCache,
 } from './pixi-app'
 import type { Viewport } from './pixi-app'
@@ -105,6 +107,7 @@ export function PixiCanvas({
   const particlesLayerRef = useRef<ParticlesLayer | null>(null)
   const bloomFilterRef = useRef<PixiBloomFilter | null>(null)
   const worldRef = useRef<Container | null>(null)
+  const boundaryRef = useRef<EventBoundary | null>(null)
   /** Set to true once boot() completes and layers are ready. */
   const readyRef = useRef(false)
   const timeRef = useRef(0)
@@ -113,9 +116,8 @@ export function PixiCanvas({
   // Stable viewport id for this component instance
   const viewportId = useId()
 
-  // IntersectionObserver visibility gating
-  const visibleRef = useRef(true)
-  const needsCatchUpRef = useRef(false)
+  // Visibility gating: IntersectionObserver + document.visibilityState
+  const { visibleRef, needsCatchUpRef } = useCanvasVisibility(containerRef, pauseWhenOffscreen)
 
   // ─── Dimensions (mirrors Canvas2D path) ─────────────────────────────────
   const [dimensions, setDimensions] = useState({ width: 800, height: 600 })
@@ -136,30 +138,6 @@ export function PixiCanvas({
     return () => observer.disconnect()
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [viewportId])
-
-  // ─── IntersectionObserver: pause render rAF when off-screen ─────────────
-  useEffect(() => {
-    if (!pauseWhenOffscreen) {
-      visibleRef.current = true
-      return
-    }
-    const el = containerRef.current
-    if (!el) return
-    const observer = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          const wasVisible = visibleRef.current
-          visibleRef.current = entry.isIntersecting
-          if (!wasVisible && entry.isIntersecting) {
-            needsCatchUpRef.current = true
-          }
-        }
-      },
-      { threshold: 0 },
-    )
-    observer.observe(el)
-    return () => observer.disconnect()
-  }, [pauseWhenOffscreen])
 
   // ─── Element ref for camera/interaction hooks ───────────────────────────
   // useCanvasCamera and useCanvasInteraction accept RefObject<HTMLElement>.
@@ -218,7 +196,7 @@ export function PixiCanvas({
   // ─── Hit-detection adapter (Pixi path) ──────────────────────────────────
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const hitTestAdapter = useMemo(
-    () => createPixiHitTestAdapter(drawPropsRef, simTimeRef),
+    () => createPixiHitTestAdapter(drawPropsRef, simTimeRef, boundaryRef),
     [],
   )
 
@@ -369,6 +347,10 @@ export function PixiCanvas({
       world.label = 'world'
       viewport.stage.addChild(world)
       worldRef.current = world
+
+      // Set up EventBoundary for per-pixel hit-testing against the world
+      setViewportBoundaryRoot(viewportId, world)
+      boundaryRef.current = viewport.boundary
 
       backgroundLayerRef.current = new BackgroundLayer()
       world.addChild(backgroundLayerRef.current.container)

--- a/web/components/agent-visualizer/pixi/pixi-canvas.tsx
+++ b/web/components/agent-visualizer/pixi/pixi-canvas.tsx
@@ -196,7 +196,7 @@ export function PixiCanvas({
   // ─── Hit-detection adapter (Pixi path) ──────────────────────────────────
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const hitTestAdapter = useMemo(
-    () => createPixiHitTestAdapter(drawPropsRef, simTimeRef, boundaryRef),
+    () => createPixiHitTestAdapter(boundaryRef),
     [],
   )
 

--- a/web/hooks/hit-test-adapters.test.ts
+++ b/web/hooks/hit-test-adapters.test.ts
@@ -80,38 +80,38 @@ describe('createCanvas2DHitTestAdapter', () => {
     const simTimeRef = { current: 0 }
     const adapter = createCanvas2DHitTestAdapter(ref, simTimeRef)
 
-    // Hit inside the main agent radius
-    expect(adapter.findAgentAt(100, 100)).toBe('a1')
+    // Hit inside the main agent radius (stage coords ignored by Canvas2D adapter)
+    expect(adapter.findAgentAt(100, 100, 0, 0)).toBe('a1')
     // Miss far away
-    expect(adapter.findAgentAt(500, 500)).toBeNull()
+    expect(adapter.findAgentAt(500, 500, 0, 0)).toBeNull()
   })
 
   it('findAgentAt returns null on empty agents', () => {
     const ref = makeDrawPropsRef(new Map(), new Map(), [])
     const simTimeRef = { current: 0 }
     const adapter = createCanvas2DHitTestAdapter(ref, simTimeRef)
-    expect(adapter.findAgentAt(0, 0)).toBeNull()
+    expect(adapter.findAgentAt(0, 0, 0, 0)).toBeNull()
   })
 
   it('findToolCallAt returns null on empty tool calls', () => {
     const ref = makeDrawPropsRef(new Map(), new Map(), [])
     const simTimeRef = { current: 0 }
     const adapter = createCanvas2DHitTestAdapter(ref, simTimeRef)
-    expect(adapter.findToolCallAt(0, 0)).toBeNull()
+    expect(adapter.findToolCallAt(0, 0, 0, 0)).toBeNull()
   })
 
   it('findDiscoveryAt returns null on empty discoveries', () => {
     const ref = makeDrawPropsRef(new Map(), new Map(), [])
     const simTimeRef = { current: 0 }
     const adapter = createCanvas2DHitTestAdapter(ref, simTimeRef)
-    expect(adapter.findDiscoveryAt(0, 0)).toBeNull()
+    expect(adapter.findDiscoveryAt(0, 0, 0, 0)).toBeNull()
   })
 
   it('findBubbleAgentAt returns null on empty agents', () => {
     const ref = makeDrawPropsRef(new Map(), new Map(), [])
     const simTimeRef = { current: 0 }
     const adapter = createCanvas2DHitTestAdapter(ref, simTimeRef)
-    expect(adapter.findBubbleAgentAt(0, 0)).toBeNull()
+    expect(adapter.findBubbleAgentAt(0, 0, 0, 0)).toBeNull()
   })
 })
 
@@ -129,85 +129,182 @@ describe('createPixiHitTestAdapter', () => {
   }
 
   it('returns an object satisfying HitTestAdapter', () => {
-    const ref = makeDrawPropsRef(new Map(), new Map(), [])
-    const simTimeRef = { current: 0 }
     const boundaryRef = { current: null }
-    const adapter = createPixiHitTestAdapter(ref, simTimeRef, boundaryRef as never)
+    const adapter = createPixiHitTestAdapter(boundaryRef as never)
     assertHitTestInterface(adapter)
   })
 
   it('findAgentAt returns agent id when hit lands on agent container', () => {
-    const ref = makeDrawPropsRef(new Map(), new Map(), [])
-    const simTimeRef = { current: 0 }
     const container = makeMockContainer('agent-abc')
     const boundaryRef = makeBoundaryRef(container)
-    const adapter = createPixiHitTestAdapter(ref, simTimeRef, boundaryRef as never)
+    const adapter = createPixiHitTestAdapter(boundaryRef as never)
 
-    expect(adapter.findAgentAt(100, 100)).toBe('abc')
+    // stageX=100, stageY=100 (world coords ignored by Pixi adapter)
+    expect(adapter.findAgentAt(0, 0, 100, 100)).toBe('abc')
+    expect(boundaryRef.current.hitTest).toHaveBeenCalledWith(100, 100)
   })
 
   it('findToolCallAt returns tool id when hit lands on tool container', () => {
-    const ref = makeDrawPropsRef(new Map(), new Map(), [])
-    const simTimeRef = { current: 0 }
     const container = makeMockContainer('tool-xyz')
     const boundaryRef = makeBoundaryRef(container)
-    const adapter = createPixiHitTestAdapter(ref, simTimeRef, boundaryRef as never)
+    const adapter = createPixiHitTestAdapter(boundaryRef as never)
 
-    expect(adapter.findToolCallAt(50, 50)).toBe('xyz')
+    expect(adapter.findToolCallAt(0, 0, 50, 50)).toBe('xyz')
+    expect(boundaryRef.current.hitTest).toHaveBeenCalledWith(50, 50)
   })
 
   it('findDiscoveryAt returns discovery id when hit lands on discovery container', () => {
-    const ref = makeDrawPropsRef(new Map(), new Map(), [])
-    const simTimeRef = { current: 0 }
     const container = makeMockContainer('discovery-d1')
     const boundaryRef = makeBoundaryRef(container)
-    const adapter = createPixiHitTestAdapter(ref, simTimeRef, boundaryRef as never)
+    const adapter = createPixiHitTestAdapter(boundaryRef as never)
 
-    expect(adapter.findDiscoveryAt(30, 30)).toBe('d1')
+    expect(adapter.findDiscoveryAt(0, 0, 30, 30)).toBe('d1')
+    expect(boundaryRef.current.hitTest).toHaveBeenCalledWith(30, 30)
   })
 
   it('findBubbleAgentAt returns agent id from bubble label', () => {
-    const ref = makeDrawPropsRef(new Map(), new Map(), [])
-    const simTimeRef = { current: 0 }
     const container = makeMockContainer('bubble-agent1')
     const boundaryRef = makeBoundaryRef(container)
-    const adapter = createPixiHitTestAdapter(ref, simTimeRef, boundaryRef as never)
+    const adapter = createPixiHitTestAdapter(boundaryRef as never)
 
-    expect(adapter.findBubbleAgentAt(10, 10)).toBe('agent1')
+    expect(adapter.findBubbleAgentAt(0, 0, 10, 10)).toBe('agent1')
+    expect(boundaryRef.current.hitTest).toHaveBeenCalledWith(10, 10)
   })
 
   it('walk-up: hit on child finds labeled parent', () => {
-    const ref = makeDrawPropsRef(new Map(), new Map(), [])
-    const simTimeRef = { current: 0 }
     const parent = makeMockContainer('agent-walk')
     const child = makeMockContainer('body', parent)
     const boundaryRef = makeBoundaryRef(child)
-    const adapter = createPixiHitTestAdapter(ref, simTimeRef, boundaryRef as never)
+    const adapter = createPixiHitTestAdapter(boundaryRef as never)
 
-    expect(adapter.findAgentAt(100, 100)).toBe('walk')
+    expect(adapter.findAgentAt(0, 0, 100, 100)).toBe('walk')
   })
 
   it('returns null when hit returns null', () => {
-    const ref = makeDrawPropsRef(new Map(), new Map(), [])
-    const simTimeRef = { current: 0 }
     const boundaryRef = makeBoundaryRef(null)
-    const adapter = createPixiHitTestAdapter(ref, simTimeRef, boundaryRef as never)
+    const adapter = createPixiHitTestAdapter(boundaryRef as never)
 
-    expect(adapter.findAgentAt(100, 100)).toBeNull()
-    expect(adapter.findToolCallAt(100, 100)).toBeNull()
-    expect(adapter.findBubbleAgentAt(100, 100)).toBeNull()
-    expect(adapter.findDiscoveryAt(100, 100)).toBeNull()
+    expect(adapter.findAgentAt(0, 0, 100, 100)).toBeNull()
+    expect(adapter.findToolCallAt(0, 0, 100, 100)).toBeNull()
+    expect(adapter.findBubbleAgentAt(0, 0, 100, 100)).toBeNull()
+    expect(adapter.findDiscoveryAt(0, 0, 100, 100)).toBeNull()
   })
 
   it('returns null when boundaryRef.current is null', () => {
-    const ref = makeDrawPropsRef(new Map(), new Map(), [])
-    const simTimeRef = { current: 0 }
     const boundaryRef = { current: null }
-    const adapter = createPixiHitTestAdapter(ref, simTimeRef, boundaryRef as never)
+    const adapter = createPixiHitTestAdapter(boundaryRef as never)
 
-    expect(adapter.findAgentAt(100, 100)).toBeNull()
-    expect(adapter.findToolCallAt(100, 100)).toBeNull()
-    expect(adapter.findBubbleAgentAt(100, 100)).toBeNull()
-    expect(adapter.findDiscoveryAt(100, 100)).toBeNull()
+    expect(adapter.findAgentAt(0, 0, 100, 100)).toBeNull()
+    expect(adapter.findToolCallAt(0, 0, 100, 100)).toBeNull()
+    expect(adapter.findBubbleAgentAt(0, 0, 100, 100)).toBeNull()
+    expect(adapter.findDiscoveryAt(0, 0, 100, 100)).toBeNull()
+  })
+
+  it('uses stage-space coords for hitTest, not world-space coords', () => {
+    // This verifies the coordinate-space fix: the adapter passes stageX/stageY
+    // (not worldX/worldY) to EventBoundary.hitTest.
+    const container = makeMockContainer('agent-test')
+    const boundaryRef = makeBoundaryRef(container)
+    const adapter = createPixiHitTestAdapter(boundaryRef as never)
+
+    // worldX=500, worldY=500 (should be ignored)
+    // stageX=200, stageY=150 (should be passed to hitTest)
+    adapter.findAgentAt(500, 500, 200, 150)
+    expect(boundaryRef.current.hitTest).toHaveBeenCalledWith(200, 150)
+  })
+})
+
+describe('createPixiHitTestAdapter — coordinate-space integration', () => {
+  /**
+   * Integration test that simulates the EventBoundary.hitTest coordinate transform
+   * behavior. In Pixi v8, hitTest(x, y) applies the root container's
+   * worldTransform.applyInverse() to convert from stage-space to local-space,
+   * then checks if children are hit at those local coords.
+   *
+   * This test verifies that under a camera pan+zoom, stage-space coords correctly
+   * resolve to the entity at the expected world position.
+   */
+  it('correctly hits entity under pan+zoom when given stage-space coords', () => {
+    // Simulate a camera: pan=(100, 50), zoom=2x
+    // worldContainer.position = (100, 50), worldContainer.scale = 2
+    // worldTransform = [2, 0, 0, 2, 100, 50]
+    // applyInverse(stageX, stageY) => ((stageX - 100) / 2, (stageY - 50) / 2)
+    const panX = 100
+    const panY = 50
+    const zoom = 2
+
+    // Agent is at world position (150, 75)
+    const agentWorldX = 150
+    const agentWorldY = 75
+    const agentRadius = 20
+
+    // The corresponding stage-space coords for this world position:
+    // stageX = agentWorldX * zoom + panX = 150 * 2 + 100 = 400
+    // stageY = agentWorldY * zoom + panY = 75 * 2 + 50 = 200
+    const stageX = agentWorldX * zoom + panX
+    const stageY = agentWorldY * zoom + panY
+
+    // Build a mock boundary that mimics the real transform math
+    const agentContainer = { label: 'agent-target', parent: null }
+    const boundaryRef = {
+      current: {
+        hitTest: vi.fn().mockImplementation((sx: number, sy: number) => {
+          // Simulate worldTransform.applyInverse: convert stage -> world
+          const localX = (sx - panX) / zoom
+          const localY = (sy - panY) / zoom
+          // Check if (localX, localY) is within agent radius
+          const dx = localX - agentWorldX
+          const dy = localY - agentWorldY
+          if (dx * dx + dy * dy <= agentRadius * agentRadius) {
+            return agentContainer
+          }
+          return null
+        }),
+      },
+    }
+
+    const adapter = createPixiHitTestAdapter(boundaryRef as never)
+
+    // Hitting at the correct stage coords should find the agent
+    expect(adapter.findAgentAt(agentWorldX, agentWorldY, stageX, stageY)).toBe('target')
+
+    // Hitting at world coords passed as stage coords would miss (the old bug)
+    // agentWorldX=150, agentWorldY=75 in stage-space would map to:
+    // localX = (150 - 100) / 2 = 25, localY = (75 - 50) / 2 = 12.5
+    // That's far from (150, 75), so it should miss
+    expect(adapter.findAgentAt(agentWorldX, agentWorldY, agentWorldX, agentWorldY)).toBeNull()
+  })
+
+  it('correctly misses entity when stage coords map to empty area', () => {
+    const panX = 50
+    const panY = 50
+    const zoom = 1.5
+
+    const agentWorldX = 200
+    const agentWorldY = 200
+    const agentRadius = 15
+
+    // Click at a stage position that maps to a world position far from the agent
+    const missStageX = 10
+    const missStageY = 10
+
+    const agentContainer = { label: 'agent-far', parent: null }
+    const boundaryRef = {
+      current: {
+        hitTest: vi.fn().mockImplementation((sx: number, sy: number) => {
+          const localX = (sx - panX) / zoom
+          const localY = (sy - panY) / zoom
+          const dx = localX - agentWorldX
+          const dy = localY - agentWorldY
+          if (dx * dx + dy * dy <= agentRadius * agentRadius) {
+            return agentContainer
+          }
+          return null
+        }),
+      },
+    }
+
+    const adapter = createPixiHitTestAdapter(boundaryRef as never)
+    expect(adapter.findAgentAt(0, 0, missStageX, missStageY)).toBeNull()
   })
 })

--- a/web/hooks/hit-test-adapters.test.ts
+++ b/web/hooks/hit-test-adapters.test.ts
@@ -116,41 +116,98 @@ describe('createCanvas2DHitTestAdapter', () => {
 })
 
 describe('createPixiHitTestAdapter', () => {
+  function makeMockContainer(label: string, parent?: { label: string; parent?: unknown }) {
+    return { label, parent: parent ?? null }
+  }
+
+  function makeBoundaryRef(hitResult: unknown) {
+    return {
+      current: {
+        hitTest: vi.fn().mockReturnValue(hitResult),
+      },
+    }
+  }
+
   it('returns an object satisfying HitTestAdapter', () => {
     const ref = makeDrawPropsRef(new Map(), new Map(), [])
     const simTimeRef = { current: 0 }
-    const adapter = createPixiHitTestAdapter(ref, simTimeRef)
+    const boundaryRef = { current: null }
+    const adapter = createPixiHitTestAdapter(ref, simTimeRef, boundaryRef as never)
     assertHitTestInterface(adapter)
   })
 
-  it('findAgentAt hits an agent at its position', () => {
-    const agents = new Map<string, Agent>()
-    agents.set('a1', makeAgent('a1', 200, 200, false))
-    const ref = makeDrawPropsRef(agents, new Map(), [])
+  it('findAgentAt returns agent id when hit lands on agent container', () => {
+    const ref = makeDrawPropsRef(new Map(), new Map(), [])
     const simTimeRef = { current: 0 }
-    const adapter = createPixiHitTestAdapter(ref, simTimeRef)
+    const container = makeMockContainer('agent-abc')
+    const boundaryRef = makeBoundaryRef(container)
+    const adapter = createPixiHitTestAdapter(ref, simTimeRef, boundaryRef as never)
 
-    // Hit inside the sub-agent radius
-    expect(adapter.findAgentAt(200, 200)).toBe('a1')
-    // Miss far away
-    expect(adapter.findAgentAt(999, 999)).toBeNull()
+    expect(adapter.findAgentAt(100, 100)).toBe('abc')
   })
 
-  it('reads from ref.current at call time, not creation time', () => {
-    const agents1 = new Map<string, Agent>()
-    const ref = makeDrawPropsRef(agents1, new Map(), [])
+  it('findToolCallAt returns tool id when hit lands on tool container', () => {
+    const ref = makeDrawPropsRef(new Map(), new Map(), [])
     const simTimeRef = { current: 0 }
-    const adapter = createPixiHitTestAdapter(ref, simTimeRef)
+    const container = makeMockContainer('tool-xyz')
+    const boundaryRef = makeBoundaryRef(container)
+    const adapter = createPixiHitTestAdapter(ref, simTimeRef, boundaryRef as never)
 
-    // Initially no agents
+    expect(adapter.findToolCallAt(50, 50)).toBe('xyz')
+  })
+
+  it('findDiscoveryAt returns discovery id when hit lands on discovery container', () => {
+    const ref = makeDrawPropsRef(new Map(), new Map(), [])
+    const simTimeRef = { current: 0 }
+    const container = makeMockContainer('discovery-d1')
+    const boundaryRef = makeBoundaryRef(container)
+    const adapter = createPixiHitTestAdapter(ref, simTimeRef, boundaryRef as never)
+
+    expect(adapter.findDiscoveryAt(30, 30)).toBe('d1')
+  })
+
+  it('findBubbleAgentAt returns agent id from bubble label', () => {
+    const ref = makeDrawPropsRef(new Map(), new Map(), [])
+    const simTimeRef = { current: 0 }
+    const container = makeMockContainer('bubble-agent1')
+    const boundaryRef = makeBoundaryRef(container)
+    const adapter = createPixiHitTestAdapter(ref, simTimeRef, boundaryRef as never)
+
+    expect(adapter.findBubbleAgentAt(10, 10)).toBe('agent1')
+  })
+
+  it('walk-up: hit on child finds labeled parent', () => {
+    const ref = makeDrawPropsRef(new Map(), new Map(), [])
+    const simTimeRef = { current: 0 }
+    const parent = makeMockContainer('agent-walk')
+    const child = makeMockContainer('body', parent)
+    const boundaryRef = makeBoundaryRef(child)
+    const adapter = createPixiHitTestAdapter(ref, simTimeRef, boundaryRef as never)
+
+    expect(adapter.findAgentAt(100, 100)).toBe('walk')
+  })
+
+  it('returns null when hit returns null', () => {
+    const ref = makeDrawPropsRef(new Map(), new Map(), [])
+    const simTimeRef = { current: 0 }
+    const boundaryRef = makeBoundaryRef(null)
+    const adapter = createPixiHitTestAdapter(ref, simTimeRef, boundaryRef as never)
+
     expect(adapter.findAgentAt(100, 100)).toBeNull()
+    expect(adapter.findToolCallAt(100, 100)).toBeNull()
+    expect(adapter.findBubbleAgentAt(100, 100)).toBeNull()
+    expect(adapter.findDiscoveryAt(100, 100)).toBeNull()
+  })
 
-    // Add an agent after adapter creation
-    const agents2 = new Map<string, Agent>()
-    agents2.set('a2', makeAgent('a2', 100, 100, true))
-    ref.current.agents = agents2
+  it('returns null when boundaryRef.current is null', () => {
+    const ref = makeDrawPropsRef(new Map(), new Map(), [])
+    const simTimeRef = { current: 0 }
+    const boundaryRef = { current: null }
+    const adapter = createPixiHitTestAdapter(ref, simTimeRef, boundaryRef as never)
 
-    // Adapter should pick up the new data
-    expect(adapter.findAgentAt(100, 100)).toBe('a2')
+    expect(adapter.findAgentAt(100, 100)).toBeNull()
+    expect(adapter.findToolCallAt(100, 100)).toBeNull()
+    expect(adapter.findBubbleAgentAt(100, 100)).toBeNull()
+    expect(adapter.findDiscoveryAt(100, 100)).toBeNull()
   })
 })

--- a/web/hooks/hit-test-adapters.ts
+++ b/web/hooks/hit-test-adapters.ts
@@ -7,6 +7,7 @@
  */
 
 import type { MutableRefObject } from 'react'
+import type { Container, EventBoundary } from 'pixi.js'
 import type { Agent, ToolCallNode, Discovery } from '@/lib/agent-types'
 import {
   findAgentAt,
@@ -38,29 +39,59 @@ export function createCanvas2DHitTestAdapter(
 }
 
 /**
- * Build a Pixi-aware hit-test adapter. In v1 this re-uses the same
- * coordinate-math functions as Canvas2D, since both renderers share the
- * same world-space data model. The Pixi display objects have
- * `eventMode='static'` set but pointer events are handled at the hook
- * level, not at the Pixi event level, to maintain a single interaction
- * code path.
+ * Walk up the display-object tree from a hit target looking for a container
+ * whose label matches a given prefix. Returns the suffix (entity ID) or null.
+ * Caps the walk at 5 levels to avoid pathological loops.
+ */
+function findLabelWithPrefix(
+  hit: Container | null,
+  prefix: string,
+): string | null {
+  let current: Container | null = hit
+  for (let i = 0; i < 5 && current; i++) {
+    const label = current.label
+    if (typeof label === 'string' && label.startsWith(prefix)) {
+      return label.slice(prefix.length)
+    }
+    current = current.parent as Container | null
+  }
+  return null
+}
+
+/**
+ * Build a Pixi-aware hit-test adapter using EventBoundary.hitTest() for
+ * per-pixel accuracy against the viewport's world container. The boundary
+ * ref is populated by pixi-canvas.tsx after registerViewport + world setup.
  *
- * In a future iteration this can be upgraded to use
- * `app.renderer.events.rootBoundary.hitTest(point)` for per-pixel
- * accuracy on irregular Pixi display objects.
+ * When the boundaryRef is null (boundary not yet created), all methods
+ * return null — the next frame's adapter call will succeed once boot
+ * completes.
  */
 export function createPixiHitTestAdapter(
-  drawPropsRef: MutableRefObject<{
+  _drawPropsRef: MutableRefObject<{
     agents: Map<string, Agent>
     toolCalls: Map<string, ToolCallNode>
     discoveries: Discovery[]
   }>,
-  simTimeRef: MutableRefObject<number>,
+  _simTimeRef: MutableRefObject<number>,
+  boundaryRef: MutableRefObject<EventBoundary | null>,
 ): HitTestAdapter {
   return {
-    findAgentAt: (x, y) => findAgentAt(x, y, drawPropsRef.current.agents),
-    findToolCallAt: (x, y) => findToolCallAt(x, y, drawPropsRef.current.toolCalls),
-    findBubbleAgentAt: (x, y) => findBubbleAgentAt(x, y, drawPropsRef.current.agents, simTimeRef.current),
-    findDiscoveryAt: (x, y) => findDiscoveryAt(x, y, drawPropsRef.current.discoveries),
+    findAgentAt: (x, y) => {
+      const hit = boundaryRef.current?.hitTest(x, y) as Container | null ?? null
+      return findLabelWithPrefix(hit, 'agent-')
+    },
+    findToolCallAt: (x, y) => {
+      const hit = boundaryRef.current?.hitTest(x, y) as Container | null ?? null
+      return findLabelWithPrefix(hit, 'tool-')
+    },
+    findBubbleAgentAt: (x, y) => {
+      const hit = boundaryRef.current?.hitTest(x, y) as Container | null ?? null
+      return findLabelWithPrefix(hit, 'bubble-')
+    },
+    findDiscoveryAt: (x, y) => {
+      const hit = boundaryRef.current?.hitTest(x, y) as Container | null ?? null
+      return findLabelWithPrefix(hit, 'discovery-')
+    },
   }
 }

--- a/web/hooks/hit-test-adapters.ts
+++ b/web/hooks/hit-test-adapters.ts
@@ -21,6 +21,8 @@ import type { HitTestAdapter } from './use-canvas-interaction'
  * Build a Canvas2D hit-test adapter that reads simulation data from a ref
  * and performs coordinate-math hit-detection against agent positions,
  * tool-call card bounds, bubble rects, and discovery card bounds.
+ *
+ * Uses world-space coords (camera transform already undone).
  */
 export function createCanvas2DHitTestAdapter(
   drawPropsRef: MutableRefObject<{
@@ -31,10 +33,10 @@ export function createCanvas2DHitTestAdapter(
   simTimeRef: MutableRefObject<number>,
 ): HitTestAdapter {
   return {
-    findAgentAt: (x, y) => findAgentAt(x, y, drawPropsRef.current.agents),
-    findToolCallAt: (x, y) => findToolCallAt(x, y, drawPropsRef.current.toolCalls),
-    findBubbleAgentAt: (x, y) => findBubbleAgentAt(x, y, drawPropsRef.current.agents, simTimeRef.current),
-    findDiscoveryAt: (x, y) => findDiscoveryAt(x, y, drawPropsRef.current.discoveries),
+    findAgentAt: (worldX, worldY) => findAgentAt(worldX, worldY, drawPropsRef.current.agents),
+    findToolCallAt: (worldX, worldY) => findToolCallAt(worldX, worldY, drawPropsRef.current.toolCalls),
+    findBubbleAgentAt: (worldX, worldY) => findBubbleAgentAt(worldX, worldY, drawPropsRef.current.agents, simTimeRef.current),
+    findDiscoveryAt: (worldX, worldY) => findDiscoveryAt(worldX, worldY, drawPropsRef.current.discoveries),
   }
 }
 
@@ -63,34 +65,33 @@ function findLabelWithPrefix(
  * per-pixel accuracy against the viewport's world container. The boundary
  * ref is populated by pixi-canvas.tsx after registerViewport + world setup.
  *
+ * Uses stage-space coords (pixel coords relative to the canvas rect, before
+ * camera transform). EventBoundary.hitTest() internally applies the inverse
+ * of the root container's worldTransform, which cancels the camera pan/zoom
+ * and tests children in their natural world positions.
+ *
  * When the boundaryRef is null (boundary not yet created), all methods
  * return null — the next frame's adapter call will succeed once boot
  * completes.
  */
 export function createPixiHitTestAdapter(
-  _drawPropsRef: MutableRefObject<{
-    agents: Map<string, Agent>
-    toolCalls: Map<string, ToolCallNode>
-    discoveries: Discovery[]
-  }>,
-  _simTimeRef: MutableRefObject<number>,
   boundaryRef: MutableRefObject<EventBoundary | null>,
 ): HitTestAdapter {
   return {
-    findAgentAt: (x, y) => {
-      const hit = boundaryRef.current?.hitTest(x, y) as Container | null ?? null
+    findAgentAt: (_worldX, _worldY, stageX, stageY) => {
+      const hit = boundaryRef.current?.hitTest(stageX, stageY) as Container | null ?? null
       return findLabelWithPrefix(hit, 'agent-')
     },
-    findToolCallAt: (x, y) => {
-      const hit = boundaryRef.current?.hitTest(x, y) as Container | null ?? null
+    findToolCallAt: (_worldX, _worldY, stageX, stageY) => {
+      const hit = boundaryRef.current?.hitTest(stageX, stageY) as Container | null ?? null
       return findLabelWithPrefix(hit, 'tool-')
     },
-    findBubbleAgentAt: (x, y) => {
-      const hit = boundaryRef.current?.hitTest(x, y) as Container | null ?? null
+    findBubbleAgentAt: (_worldX, _worldY, stageX, stageY) => {
+      const hit = boundaryRef.current?.hitTest(stageX, stageY) as Container | null ?? null
       return findLabelWithPrefix(hit, 'bubble-')
     },
-    findDiscoveryAt: (x, y) => {
-      const hit = boundaryRef.current?.hitTest(x, y) as Container | null ?? null
+    findDiscoveryAt: (_worldX, _worldY, stageX, stageY) => {
+      const hit = boundaryRef.current?.hitTest(stageX, stageY) as Container | null ?? null
       return findLabelWithPrefix(hit, 'discovery-')
     },
   }

--- a/web/hooks/use-canvas-interaction.ts
+++ b/web/hooks/use-canvas-interaction.ts
@@ -12,18 +12,20 @@ import type { Transform } from './use-canvas-camera'
 /**
  * Renderer-agnostic hit-detection adapter.
  *
- * Each function takes world-space (canvas-local) coordinates and returns
- * the id of the hit entity, or null.
+ * Each function receives both coordinate spaces:
+ *   - worldX/worldY: world-space coords (camera transform already undone)
+ *   - stageX/stageY: stage-space coords (pixel coords relative to canvas rect,
+ *     before camera transform is applied)
  *
- * The Canvas2D path supplies functions that iterate agent/tool-call/discovery
- * data structures directly. The Pixi path can supply functions that use
- * Pixi's event system or iterate display-object containers.
+ * The Canvas2D adapter uses world-space (coordinate-math hit-detection).
+ * The Pixi adapter uses stage-space (EventBoundary.hitTest internally applies
+ * the inverse of the world container's transform).
  */
 export interface HitTestAdapter {
-  findAgentAt: (x: number, y: number) => string | null
-  findToolCallAt: (x: number, y: number) => string | null
-  findBubbleAgentAt: (x: number, y: number) => string | null
-  findDiscoveryAt: (x: number, y: number) => string | null
+  findAgentAt: (worldX: number, worldY: number, stageX: number, stageY: number) => string | null
+  findToolCallAt: (worldX: number, worldY: number, stageX: number, stageY: number) => string | null
+  findBubbleAgentAt: (worldX: number, worldY: number, stageX: number, stageY: number) => string | null
+  findDiscoveryAt: (worldX: number, worldY: number, stageX: number, stageY: number) => string | null
 }
 
 interface InteractionCallbacks {
@@ -95,33 +97,44 @@ export function useCanvasInteraction({
   const lastPanPosRef = useRef({ x: 0, y: 0, time: 0 })
   const lastHoveredIdRef = useRef<string | null>(null)
 
+  // ─── Stage-space helper ──────────────────────────────────────────────────
+  // Stage-space = pixel coords relative to the canvas element rect (before
+  // camera transform). Needed by the Pixi hit-test adapter.
+  const screenToStage = useCallback((screenX: number, screenY: number) => {
+    const canvas = mainCanvasRef.current
+    if (!canvas) return { x: 0, y: 0 }
+    const rect = canvas.getBoundingClientRect()
+    return { x: screenX - rect.left, y: screenY - rect.top }
+  }, [mainCanvasRef])
+
   // ─── Hit detection — renderer-agnostic adapter or Canvas2D fallback ─────
 
-  const findAgentAt = useCallback((x: number, y: number): string | null => {
-    if (hitTestAdapter) return hitTestAdapter.findAgentAt(x, y)
-    return findAgentAtPure(x, y, drawPropsRef.current.agents)
+  const findAgentAt = useCallback((worldX: number, worldY: number, stageX: number, stageY: number): string | null => {
+    if (hitTestAdapter) return hitTestAdapter.findAgentAt(worldX, worldY, stageX, stageY)
+    return findAgentAtPure(worldX, worldY, drawPropsRef.current.agents)
   }, [drawPropsRef, hitTestAdapter])
 
-  const findToolCallAt = useCallback((x: number, y: number): string | null => {
-    if (hitTestAdapter) return hitTestAdapter.findToolCallAt(x, y)
-    return findToolCallAtPure(x, y, drawPropsRef.current.toolCalls)
+  const findToolCallAt = useCallback((worldX: number, worldY: number, stageX: number, stageY: number): string | null => {
+    if (hitTestAdapter) return hitTestAdapter.findToolCallAt(worldX, worldY, stageX, stageY)
+    return findToolCallAtPure(worldX, worldY, drawPropsRef.current.toolCalls)
   }, [drawPropsRef, hitTestAdapter])
 
-  const findBubbleAgentAt = useCallback((x: number, y: number): string | null => {
-    if (hitTestAdapter) return hitTestAdapter.findBubbleAgentAt(x, y)
-    return findBubbleAgentAtPure(x, y, drawPropsRef.current.agents, simTimeRef.current)
+  const findBubbleAgentAt = useCallback((worldX: number, worldY: number, stageX: number, stageY: number): string | null => {
+    if (hitTestAdapter) return hitTestAdapter.findBubbleAgentAt(worldX, worldY, stageX, stageY)
+    return findBubbleAgentAtPure(worldX, worldY, drawPropsRef.current.agents, simTimeRef.current)
   }, [drawPropsRef, simTimeRef, hitTestAdapter])
 
-  const findDiscoveryAt = useCallback((x: number, y: number): string | null => {
-    if (hitTestAdapter) return hitTestAdapter.findDiscoveryAt(x, y)
-    return findDiscoveryAtPure(x, y, drawPropsRef.current.discoveries)
+  const findDiscoveryAt = useCallback((worldX: number, worldY: number, stageX: number, stageY: number): string | null => {
+    if (hitTestAdapter) return hitTestAdapter.findDiscoveryAt(worldX, worldY, stageX, stageY)
+    return findDiscoveryAtPure(worldX, worldY, drawPropsRef.current.discoveries)
   }, [drawPropsRef, hitTestAdapter])
 
   // ─── Mouse Handlers ─────────────────────────────────────────────────────
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     const pos = screenToCanvas(e.clientX, e.clientY)
-    const agentId = findAgentAt(pos.x, pos.y)
+    const stage = screenToStage(e.clientX, e.clientY)
+    const agentId = findAgentAt(pos.x, pos.y, stage.x, stage.y)
     if (e.button === 0) {
       panVelocityRef.current = { vx: 0, vy: 0, active: false }
       setIsDragging(true)
@@ -132,11 +145,12 @@ export function useCanvasInteraction({
         lastPanPosRef.current = { x: e.clientX, y: e.clientY, time: performance.now() }
       }
     }
-  }, [screenToCanvas, findAgentAt, panVelocityRef])
+  }, [screenToCanvas, screenToStage, findAgentAt, panVelocityRef])
 
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
     const pos = screenToCanvas(e.clientX, e.clientY)
-    const hoveredId = findAgentAt(pos.x, pos.y)
+    const stage = screenToStage(e.clientX, e.clientY)
+    const hoveredId = findAgentAt(pos.x, pos.y, stage.x, stage.y)
     if (hoveredId !== lastHoveredIdRef.current) {
       lastHoveredIdRef.current = hoveredId
       drawPropsRef.current.onAgentHover(hoveredId)
@@ -166,7 +180,7 @@ export function useCanvasInteraction({
         }
       }
     }
-  }, [screenToCanvas, findAgentAt, drawPropsRef, userHasNavigatedRef, transformRef, panVelocityRef])
+  }, [screenToCanvas, screenToStage, findAgentAt, drawPropsRef, userHasNavigatedRef, transformRef, panVelocityRef])
 
   const handleMouseUp = useCallback((e: React.MouseEvent) => {
     if (e.button === 2) {
@@ -186,20 +200,21 @@ export function useCanvasInteraction({
       : 0
     if (screenDist < ANIM.dragThresholdPx) {
       const pos = screenToCanvas(e.clientX, e.clientY)
-      const agentId = findAgentAt(pos.x, pos.y)
+      const stage = screenToStage(e.clientX, e.clientY)
+      const agentId = findAgentAt(pos.x, pos.y, stage.x, stage.y)
       const p = drawPropsRef.current
       if (agentId) {
         p.onAgentClick(agentId)
       } else {
-        const bubbleAgentId = findBubbleAgentAt(pos.x, pos.y)
+        const bubbleAgentId = findBubbleAgentAt(pos.x, pos.y, stage.x, stage.y)
         if (bubbleAgentId) {
           p.onAgentClick(bubbleAgentId)
         } else {
-          const toolId = findToolCallAt(pos.x, pos.y)
+          const toolId = findToolCallAt(pos.x, pos.y, stage.x, stage.y)
           if (toolId) {
             p.onToolCallClick?.(toolId)
           } else {
-            const discId = findDiscoveryAt(pos.x, pos.y)
+            const discId = findDiscoveryAt(pos.x, pos.y, stage.x, stage.y)
             if (discId) {
               p.onDiscoveryClick?.(discId)
             } else {
@@ -217,7 +232,7 @@ export function useCanvasInteraction({
     }
     setIsDragging(false)
     dragTargetRef.current = null
-  }, [screenToCanvas, findAgentAt, findBubbleAgentAt, findToolCallAt, findDiscoveryAt, drawPropsRef, panVelocityRef])
+  }, [screenToCanvas, screenToStage, findAgentAt, findBubbleAgentAt, findToolCallAt, findDiscoveryAt, drawPropsRef, panVelocityRef])
 
   // Wheel handler attached as native event (passive: false) to allow preventDefault
   const handleWheelRef = useRef<(e: WheelEvent) => void>(() => {})
@@ -250,7 +265,8 @@ export function useCanvasInteraction({
     // Double-click on an agent → consumer-defined behavior (rename inline).
     // Double-click on empty space → zoom-to-fit.
     const pos = screenToCanvas(e.clientX, e.clientY)
-    const agentId = findAgentAt(pos.x, pos.y)
+    const stage = screenToStage(e.clientX, e.clientY)
+    const agentId = findAgentAt(pos.x, pos.y, stage.x, stage.y)
     const onAgentDoubleClick = drawPropsRef.current.onAgentDoubleClick
     if (agentId && onAgentDoubleClick) {
       const canvas = mainCanvasRef.current
@@ -263,14 +279,15 @@ export function useCanvasInteraction({
       return
     }
     doZoomToFit()
-  }, [screenToCanvas, findAgentAt, drawPropsRef, doZoomToFit, mainCanvasRef])
+  }, [screenToCanvas, screenToStage, findAgentAt, drawPropsRef, doZoomToFit, mainCanvasRef])
 
   const handleContextMenuEvent = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
     const pos = screenToCanvas(e.clientX, e.clientY)
-    const agentId = findAgentAt(pos.x, pos.y)
+    const stage = screenToStage(e.clientX, e.clientY)
+    const agentId = findAgentAt(pos.x, pos.y, stage.x, stage.y)
     drawPropsRef.current.onContextMenu(e, agentId ? 'agent' : 'canvas', agentId ?? undefined)
-  }, [screenToCanvas, findAgentAt, drawPropsRef])
+  }, [screenToCanvas, screenToStage, findAgentAt, drawPropsRef])
 
   const handleMouseLeave = useCallback(() => {
     setIsDragging(false)

--- a/web/hooks/use-canvas-visibility.test.ts
+++ b/web/hooks/use-canvas-visibility.test.ts
@@ -78,6 +78,102 @@ function fireIO(intersecting: boolean) {
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
+describe('useCanvasVisibility — cross-window ownerDocument', () => {
+  it('attaches visibility listener to ownerDocument, not global document', () => {
+    // Create a secondary document (simulates a detached/pop-out window)
+    const secondaryDoc = document.implementation.createHTMLDocument('test')
+    // jsdom creates docs with visibilityState='prerender'; override to 'visible'
+    Object.defineProperty(secondaryDoc, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+
+    // Create element in the secondary document
+    const el = secondaryDoc.createElement('div')
+    secondaryDoc.body.appendChild(el)
+    const containerRef = { current: el }
+
+    // Spy on the secondary document's addEventListener
+    const addSpy = vi.spyOn(secondaryDoc, 'addEventListener')
+
+    const { result } = renderHook(() => useCanvasVisibility(containerRef, true))
+
+    // Verify listener was attached to the secondary document
+    expect(addSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+
+    // Verify initial state is visible
+    expect(result.current.visibleRef.current).toBe(true)
+
+    addSpy.mockRestore()
+  })
+
+  it('responds to visibilitychange on ownerDocument, not global document', () => {
+    const secondaryDoc = document.implementation.createHTMLDocument('test')
+    Object.defineProperty(secondaryDoc, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+    const el = secondaryDoc.createElement('div')
+    secondaryDoc.body.appendChild(el)
+    const containerRef = { current: el }
+
+    const { result } = renderHook(() => useCanvasVisibility(containerRef, true))
+
+    // Initially visible
+    expect(result.current.visibleRef.current).toBe(true)
+
+    // Simulate the secondary document going hidden
+    Object.defineProperty(secondaryDoc, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    })
+    act(() => {
+      secondaryDoc.dispatchEvent(new Event('visibilitychange'))
+    })
+    expect(result.current.visibleRef.current).toBe(false)
+
+    // Dispatching visibilitychange on the GLOBAL document should NOT affect this hook
+    // (global document is still 'visible')
+    result.current.needsCatchUpRef.current = false
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    // Should still be false — the hook listens to secondaryDoc, not global doc
+    expect(result.current.visibleRef.current).toBe(false)
+
+    // Bring the secondary doc back to visible
+    Object.defineProperty(secondaryDoc, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+    act(() => {
+      secondaryDoc.dispatchEvent(new Event('visibilitychange'))
+    })
+    expect(result.current.visibleRef.current).toBe(true)
+    expect(result.current.needsCatchUpRef.current).toBe(true)
+  })
+
+  it('global document visibility has no effect when element is in secondary document', () => {
+    const secondaryDoc = document.implementation.createHTMLDocument('test')
+    Object.defineProperty(secondaryDoc, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+    const el = secondaryDoc.createElement('div')
+    secondaryDoc.body.appendChild(el)
+    const containerRef = { current: el }
+
+    const { result } = renderHook(() => useCanvasVisibility(containerRef, true))
+
+    // Make global document hidden
+    setDocVisibility('hidden')
+    act(() => { fireVisibilityChange() })
+
+    // Hook should still be visible (it's watching secondaryDoc, not global doc)
+    expect(result.current.visibleRef.current).toBe(true)
+  })
+})
+
 describe('useCanvasVisibility', () => {
   it('IO visible + doc visible → visibleRef is true', () => {
     const containerRef = makeContainerRef()

--- a/web/hooks/use-canvas-visibility.test.ts
+++ b/web/hooks/use-canvas-visibility.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for useCanvasVisibility hook.
+ *
+ * Validates the combined IntersectionObserver + document.visibilityState
+ * gating logic, transition catch-up behavior, and pauseWhenOffscreen bypass.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useCanvasVisibility } from './use-canvas-visibility'
+
+// ─── IntersectionObserver mock ──────────────────────────────────────────────
+
+type IOCallback = (entries: Array<{ isIntersecting: boolean }>) => void
+
+let ioInstances: Array<{ callback: IOCallback; disconnect: ReturnType<typeof vi.fn> }>
+
+class MockIntersectionObserver {
+  callback: IOCallback
+  disconnect = vi.fn()
+
+  constructor(callback: IOCallback) {
+    this.callback = callback
+    ioInstances.push({ callback, disconnect: this.disconnect })
+  }
+
+  observe() {
+    // Fire initial callback as "intersecting" (matches real IO behavior)
+    this.callback([{ isIntersecting: true }])
+  }
+
+  unobserve() { /* no-op */ }
+}
+
+// ─── Setup / teardown ───────────────────────────────────────────────────────
+
+beforeEach(() => {
+  ioInstances = []
+  vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+  // Default: document is visible
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => 'visible',
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeContainerRef() {
+  // Create a real element so ownerDocument works
+  const el = document.createElement('div')
+  return { current: el }
+}
+
+function setDocVisibility(state: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => state,
+  })
+}
+
+function fireVisibilityChange() {
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+function fireIO(intersecting: boolean) {
+  const instance = ioInstances[ioInstances.length - 1]
+  if (instance) {
+    act(() => {
+      instance.callback([{ isIntersecting: intersecting }])
+    })
+  }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('useCanvasVisibility', () => {
+  it('IO visible + doc visible → visibleRef is true', () => {
+    const containerRef = makeContainerRef()
+    const { result } = renderHook(() => useCanvasVisibility(containerRef, true))
+
+    // IO fires "intersecting" on observe, doc is visible
+    expect(result.current.visibleRef.current).toBe(true)
+  })
+
+  it('IO visible + doc hidden → visibleRef is false', () => {
+    setDocVisibility('hidden')
+    const containerRef = makeContainerRef()
+    const { result } = renderHook(() => useCanvasVisibility(containerRef, true))
+
+    // IO fires intersecting, but doc is hidden
+    expect(result.current.visibleRef.current).toBe(false)
+  })
+
+  it('IO hidden + doc visible → visibleRef is false', () => {
+    const containerRef = makeContainerRef()
+    const { result } = renderHook(() => useCanvasVisibility(containerRef, true))
+
+    // IO initially fires as visible, then goes out of viewport
+    fireIO(false)
+    expect(result.current.visibleRef.current).toBe(false)
+  })
+
+  it('transition hidden → visible sets needsCatchUpRef to true', () => {
+    const containerRef = makeContainerRef()
+    const { result } = renderHook(() => useCanvasVisibility(containerRef, true))
+
+    // Start visible
+    expect(result.current.visibleRef.current).toBe(true)
+
+    // Go off-screen
+    fireIO(false)
+    expect(result.current.visibleRef.current).toBe(false)
+    // Reset catch-up flag manually (simulating the draw loop consuming it)
+    result.current.needsCatchUpRef.current = false
+
+    // Come back on-screen
+    fireIO(true)
+    expect(result.current.visibleRef.current).toBe(true)
+    expect(result.current.needsCatchUpRef.current).toBe(true)
+  })
+
+  it('transition via visibilitychange sets needsCatchUpRef', () => {
+    const containerRef = makeContainerRef()
+    const { result } = renderHook(() => useCanvasVisibility(containerRef, true))
+
+    // Go hidden via document
+    setDocVisibility('hidden')
+    act(() => { fireVisibilityChange() })
+    expect(result.current.visibleRef.current).toBe(false)
+    result.current.needsCatchUpRef.current = false
+
+    // Come back visible
+    setDocVisibility('visible')
+    act(() => { fireVisibilityChange() })
+    expect(result.current.visibleRef.current).toBe(true)
+    expect(result.current.needsCatchUpRef.current).toBe(true)
+  })
+
+  it('pauseWhenOffscreen=false → always visible', () => {
+    setDocVisibility('hidden')
+    const containerRef = makeContainerRef()
+    const { result } = renderHook(() => useCanvasVisibility(containerRef, false))
+
+    expect(result.current.visibleRef.current).toBe(true)
+    // No IO should be created
+    expect(ioInstances.length).toBe(0)
+  })
+
+  it('cleans up IO and event listener on unmount', () => {
+    const containerRef = makeContainerRef()
+    const { unmount } = renderHook(() => useCanvasVisibility(containerRef, true))
+
+    expect(ioInstances.length).toBe(1)
+    unmount()
+    expect(ioInstances[0].disconnect).toHaveBeenCalled()
+  })
+})

--- a/web/hooks/use-canvas-visibility.ts
+++ b/web/hooks/use-canvas-visibility.ts
@@ -17,9 +17,9 @@
  * rather than the global `document`. This ensures minimizing the secondary
  * window correctly pauses rendering in that window.
  *
- * Trade-off: ownerDocument is read once at effect time. If the container
- * element is re-parented to a different document, the effect must re-bind
- * (handled via the dependency array including containerRef.current).
+ * Trade-off: ownerDocument is read once at mount time. Re-parenting the
+ * container element to a different document at runtime is not supported —
+ * the hook would need to be remounted (e.g. via a key change) to rebind.
  */
 
 import { useEffect, useRef, type MutableRefObject, type RefObject } from 'react'

--- a/web/hooks/use-canvas-visibility.ts
+++ b/web/hooks/use-canvas-visibility.ts
@@ -1,0 +1,97 @@
+/**
+ * Hook that combines IntersectionObserver + document.visibilityState to
+ * determine whether the render rAF should run for a given canvas.
+ *
+ * The render path gates on `visibleRef.current`:
+ *   visibleRef = isInViewport AND isDocumentVisible
+ *
+ * When the canvas transitions from hidden to visible, `needsCatchUpRef`
+ * is set to true so the draw loop can force one immediate redraw to catch
+ * up with simulation changes that occurred while off-screen.
+ *
+ * The simulation sub-state keeps ticking regardless of visibility — only
+ * the render path is gated.
+ *
+ * For cross-window / detached panels (created via window.open), the hook
+ * listens to `visibilitychange` on `containerRef.current.ownerDocument`
+ * rather than the global `document`. This ensures minimizing the secondary
+ * window correctly pauses rendering in that window.
+ *
+ * Trade-off: ownerDocument is read once at effect time. If the container
+ * element is re-parented to a different document, the effect must re-bind
+ * (handled via the dependency array including containerRef.current).
+ */
+
+import { useEffect, useRef, type MutableRefObject, type RefObject } from 'react'
+
+export interface CanvasVisibility {
+  visibleRef: MutableRefObject<boolean>
+  needsCatchUpRef: MutableRefObject<boolean>
+}
+
+export function useCanvasVisibility(
+  containerRef: RefObject<HTMLElement | null>,
+  pauseWhenOffscreen: boolean,
+): CanvasVisibility {
+  const visibleRef = useRef(true)
+  const needsCatchUpRef = useRef(false)
+
+  // Internal sub-state refs
+  const isInViewportRef = useRef(true)
+  const isDocVisibleRef = useRef(true)
+
+  // ─── IntersectionObserver + visibilitychange ──────────────────────────
+  useEffect(() => {
+    if (!pauseWhenOffscreen) {
+      visibleRef.current = true
+      isInViewportRef.current = true
+      isDocVisibleRef.current = true
+      return
+    }
+
+    const el = containerRef.current
+    if (!el) return
+
+    const ownerDoc = el.ownerDocument ?? document
+
+    // Helper: recompute combined visibility and handle transitions
+    const recompute = () => {
+      const prev = visibleRef.current
+      const next = isInViewportRef.current && isDocVisibleRef.current
+      visibleRef.current = next
+      if (!prev && next) {
+        needsCatchUpRef.current = true
+      }
+    }
+
+    // Initial document visibility state
+    isDocVisibleRef.current = ownerDoc.visibilityState === 'visible'
+    recompute()
+
+    // IntersectionObserver
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          isInViewportRef.current = entry.isIntersecting
+        }
+        recompute()
+      },
+      { threshold: 0 },
+    )
+    io.observe(el)
+
+    // visibilitychange listener on ownerDocument
+    const onVisChange = () => {
+      isDocVisibleRef.current = ownerDoc.visibilityState === 'visible'
+      recompute()
+    }
+    ownerDoc.addEventListener('visibilitychange', onVisChange)
+
+    return () => {
+      io.disconnect()
+      ownerDoc.removeEventListener('visibilitychange', onVisChange)
+    }
+  }, [pauseWhenOffscreen, containerRef])
+
+  return { visibleRef, needsCatchUpRef }
+}


### PR DESCRIPTION
Two Pixi-migration follow-ups bundled in one PR. Both originate from concerns flagged during PR #36 review.

**Closes #33, closes #34.**

## What changed

### #33 — visibility gating combines IntersectionObserver + ownerDocument.visibilityState

Extracted a shared `useCanvasVisibility` hook (`web/hooks/use-canvas-visibility.ts`) that combines two signals: the existing IntersectionObserver, plus the canvas container's `ownerDocument.visibilityState`. The render rAF only fires when both report visible; transitions hidden→visible flip `needsCatchUpRef` for an immediate catch-up frame.

Why `ownerDocument` rather than the global `document`: detached cross-window panels (PR #1's multi-window feature) live in `window.open`'d documents. Their visibility state is independent of the parent window's — minimizing a popout flips that document's `visibilityState`, but the global `document` keeps reporting visible. Listening on `containerRef.current.ownerDocument` correctly handles both single-window and multi-window scenarios.

Sub-state simulation continues ticking regardless of visibility — only the **render** path gates. Stats panels stay fresh.

The inline IO effects in `canvas.tsx` and `pixi-canvas.tsx` were duplicated; the new hook deduplicates them.

### #34 — per-pixel hit-test via per-viewport EventBoundary

Replaced the coordinate-math fallback in `createPixiHitTestAdapter` with `EventBoundary.hitTest()`. Architectural twist: the shared renderer renders viewport stages to off-screen `RenderTexture`s, so `app.renderer.events.rootBoundary` (rooted on the app stage) cannot find viewport-stage children. Solution: **one `EventBoundary` per viewport**, rooted on the viewport's world container, stored on the `Viewport` record in `pixi-app.ts`.

Coord-space contract: `EventBoundary.hitTest()` walks down via `worldTransform.applyInverse`, so it expects **stage-space** coords (rect-relative pixel coords) — not world-space coords post-`screenToCanvas`. The `HitTestAdapter` interface was extended to accept both `(worldX, worldY, stageX, stageY)`. The Pixi adapter consumes stage; the Canvas2D adapter continues to use world. A new `screenToStage` helper in `use-canvas-interaction.ts` computes the rect-relative pair.

Pre-work: `eventMode = 'static'` added to agent and bubble containers (tool-calls and discoveries already had it). Bubble pool entries get `bubble-${agentId}` labels on acquire.

Identity walk-up: hits may land on inner Sprite/Graphics children rather than the labeled container itself, so the adapter walks up parents (max 5 levels) until a matching `agent-`, `tool-`, `discovery-`, or `bubble-` prefix is found.

## Test plan

### Headless (verified clean before push)

- [x] `cd web && pnpm typecheck` — zero errors
- [x] `cd web && pnpm test` — 156/156 (was 134/134 before this branch — +22 covering the new hook and adapter paths)
- [x] `cd web && pnpm build` — clean
- [x] `cd web && pnpm build:webview` — 285.56 kB gzip (essentially flat vs main)
- [x] `cd extension && pnpm test` — 28/28

### Manual verification (cannot validate headlessly)

- [ ] Default Canvas2D path — byte-identical behavior; visual parity with main
- [ ] `?renderer=pixi` — click/hover hit-detection works for agents, tool-cards, discoveries, bubbles, with the camera both at default and after pan+zoom (this is the #34 correctness gate)
- [ ] Detach a session into a `window.open` panel; minimize that window; confirm via DevTools Performance recording that render rAF fully stops for the detached canvas (this is the #33 correctness gate)
- [ ] Re-focus the popout — first frame draws via `needsCatchUpRef`, no visible stutter
- [ ] Switch tabs in a single-window setup — render rAF pauses; switch back, catch-up frame draws

## Notable design decisions

- **Coord-space split in the adapter interface** rather than branching on adapter type at the call site. Branching at the call site would leak Pixi/Canvas2D awareness into `use-canvas-interaction.ts`, which is exactly what the adapter abstracts.
- **`ownerDocument` read once at effect mount.** Re-parenting a container to a different document at runtime is not supported — that scenario requires a key-based remount. Documented in the hook.
- **Bubble labels set on acquire from pool, not on create.** Pooled entries reused for a different agent always get re-labeled before the next hit-test sees them.
- **Walk-up cap of 5 levels** in the adapter. Confirmed by reading layer `createEntry` methods — actual scene-graph depth is at most 3.

## Notes

- #35 was triaged during this PR. Detailed findings and a spike plan posted to the issue — short version: not actually blocked on Pixi (v8.18.1 already accepts `target: ICanvas`), but verifying the single-GL-context invariant requires a separate spike. Kept out of scope here.
- Two functional commits (one per issue) plus one fix commit addressing review findings (coord-space bug, dead params, missing tests). Diff is reviewable issue-by-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)