### PR TITLE
perf(pixi): shared renderer migrates to multiView (rebased onto main)

### DIFF
--- a/web/components/agent-visualizer/pixi/pixi-app.test.ts
+++ b/web/components/agent-visualizer/pixi/pixi-app.test.ts
@@ -5,32 +5,17 @@
  *   - Singleton renderer: multiple acquires share one Application
  *   - Viewport registration / deregistration
  *   - Ref counting: release when all viewports gone
+ *   - multiView init and direct render-to-canvas
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // ─── Mock pixi.js ────────────────────────────────────────────────────────
 
-const mockCtx = {
-  font: '',
-  textBaseline: '',
-  fillStyle: '',
-  measureText: (text: string) => ({ width: text.length * 6 }),
-  fillText: vi.fn(),
-  clearRect: vi.fn(),
-  drawImage: vi.fn(),
-}
-
 const origCreateElement = document.createElement.bind(document)
-vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
-  const el = origCreateElement(tag)
-  if (tag === 'canvas') {
-    (el as HTMLCanvasElement).getContext = (() => mockCtx) as unknown as HTMLCanvasElement['getContext']
-  }
-  return el
-})
 
 let appInstanceCount = 0
+let lastInitOpts: Record<string, unknown> | null = null
 
 vi.mock('pixi.js', () => {
   class MockContainer {
@@ -60,12 +45,6 @@ vi.mock('pixi.js', () => {
     static from(_opts: unknown): MockTexture { return new MockTexture() }
   }
 
-  class MockRenderTexture {
-    _destroyed = false
-    destroy() { this._destroyed = true }
-    static create(_opts: unknown): MockRenderTexture { return new MockRenderTexture() }
-  }
-
   class MockRectangle {
     x: number; y: number; width: number; height: number
     constructor(x = 0, y = 0, w = 0, h = 0) {
@@ -79,9 +58,6 @@ vi.mock('pixi.js', () => {
     renderer = {
       resolution: 1,
       render: vi.fn(),
-      extract: {
-        canvas: vi.fn(() => origCreateElement('canvas')),
-      },
       destroy: vi.fn(),
     }
     _destroyed = false
@@ -90,8 +66,8 @@ vi.mock('pixi.js', () => {
       appInstanceCount++
     }
 
-    async init(_opts: unknown) {
-      // no-op
+    async init(opts: Record<string, unknown>) {
+      lastInitOpts = opts
     }
 
     destroy() {
@@ -112,7 +88,6 @@ vi.mock('pixi.js', () => {
     Container: MockContainer,
     EventBoundary: MockEventBoundary,
     Texture: MockTexture,
-    RenderTexture: MockRenderTexture,
     Rectangle: MockRectangle,
   }
 })
@@ -126,6 +101,8 @@ import {
   deregisterViewport,
   setViewportBoundaryRoot,
   getViewportBoundary,
+  bindViewportCanvas,
+  renderViewport,
   getViewportCount,
   isSharedRendererActive,
 } from './pixi-app'
@@ -136,6 +113,7 @@ import { Container } from 'pixi.js'
 describe('Shared Pixi Renderer', () => {
   beforeEach(() => {
     appInstanceCount = 0
+    lastInitOpts = null
     // Clean up any leftover state from previous tests
     while (isSharedRendererActive()) {
       releaseSharedRenderer()
@@ -156,6 +134,16 @@ describe('Shared Pixi Renderer', () => {
     expect(appInstanceCount).toBe(1)
 
     releaseSharedRenderer()
+    releaseSharedRenderer()
+  })
+
+  it('initializes with multiView: true', async () => {
+    await acquireSharedRenderer()
+
+    expect(lastInitOpts).toBeDefined()
+    expect(lastInitOpts!.multiView).toBe(true)
+    expect(lastInitOpts!.preference).toBe('webgl')
+
     releaseSharedRenderer()
   })
 
@@ -268,6 +256,58 @@ describe('Shared Pixi Renderer', () => {
     deregisterViewport('vp-null')
     expect(vp.boundary).toBeNull()
 
+    releaseSharedRenderer()
+  })
+
+  it('renderViewport calls renderer.render with target canvas and clear', async () => {
+    const app = await acquireSharedRenderer()
+    registerViewport('vp-render')
+
+    const canvas = origCreateElement('canvas')
+    bindViewportCanvas('vp-render', canvas, 800, 600)
+
+    const vp = registerViewport('vp-render') // returns existing
+
+    renderViewport('vp-render')
+
+    const renderMock = app.renderer.render as ReturnType<typeof vi.fn>
+    expect(renderMock).toHaveBeenCalledTimes(1)
+    expect(renderMock).toHaveBeenCalledWith({
+      container: vp.stage,
+      target: canvas,
+      clear: true,
+    })
+
+    deregisterViewport('vp-render')
+    releaseSharedRenderer()
+  })
+
+  it('renderViewport does not call extract.canvas', async () => {
+    const app = await acquireSharedRenderer()
+    registerViewport('vp-noextract')
+
+    const canvas = origCreateElement('canvas')
+    bindViewportCanvas('vp-noextract', canvas, 400, 300)
+
+    renderViewport('vp-noextract')
+
+    // The renderer should not have an extract property used
+    expect((app.renderer as unknown as Record<string, unknown>).extract).toBeUndefined()
+
+    deregisterViewport('vp-noextract')
+    releaseSharedRenderer()
+  })
+
+  it('renderViewport is a no-op when canvas is not bound', async () => {
+    const app = await acquireSharedRenderer()
+    registerViewport('vp-nocanvas')
+
+    renderViewport('vp-nocanvas')
+
+    const renderMock = app.renderer.render as ReturnType<typeof vi.fn>
+    expect(renderMock).not.toHaveBeenCalled()
+
+    deregisterViewport('vp-nocanvas')
     releaseSharedRenderer()
   })
 })

--- a/web/components/agent-visualizer/pixi/pixi-app.ts
+++ b/web/components/agent-visualizer/pixi/pixi-app.ts
@@ -1,14 +1,16 @@
 /**
- * Shared Pixi v8 renderer — singleton GL context + multi-viewport.
+ * Shared Pixi v8 renderer — singleton GL context + multi-viewport via multiView.
  *
  * Architecture:
- *   - ONE Application (one GL context, one offscreen WebGL canvas).
+ *   - ONE Application with `multiView: true` (one hidden GL canvas, one
+ *     WebGL context shared across all viewports).
  *   - N viewports: each PixiCanvas registers a viewport on mount and
  *     deregisters on unmount.
  *   - Each viewport owns a Container (its scene-graph subtree) and a
- *     RenderTexture. On each frame, the shared renderer renders the
- *     viewport's container into its RenderTexture, then blits the result
- *     to the viewport's visible <canvas> via Canvas2D drawImage.
+ *     visible <canvas>. On each frame, the shared renderer renders the
+ *     viewport's container directly to its visible canvas via
+ *     `renderer.render({ container, target: canvas, clear: true })`.
+ *     Pixi's multiView postrender handles the internal blit.
  *   - Texture atlases (glyphs, glow sprites, circle sprites) live on the
  *     shared renderer — no per-canvas duplication.
  *
@@ -17,7 +19,7 @@
  * calls sharedRenderer.renderViewport() for its viewport id.
  */
 
-import { Application, Container, EventBoundary, RenderTexture, Texture } from 'pixi.js'
+import { Application, Container, EventBoundary, Texture } from 'pixi.js'
 
 // ─── Viewport registry ─────────────────────────────────────────────────────
 
@@ -27,12 +29,8 @@ export interface Viewport {
   id: string
   /** Root container for this viewport's scene graph. */
   stage: Container
-  /** Off-screen render texture sized to this viewport's dimensions. */
-  renderTexture: RenderTexture | null
   /** The visible <canvas> element in the DOM for this viewport. */
   canvas: HTMLCanvasElement | null
-  /** Canvas 2D context for blitting the render texture to the visible canvas. */
-  ctx: CanvasRenderingContext2D | null
   /** Current viewport dimensions in CSS pixels. */
   width: number
   height: number
@@ -79,14 +77,13 @@ export async function acquireSharedRenderer(): Promise<Application> {
   }
   shared = state
 
-  // Create a hidden offscreen canvas for the GL context. It won't be
-  // appended to the DOM — rendering goes through RenderTextures.
   state.initPromise = app.init({
     backgroundColor: 0x050510,
     antialias: true,
     resolution: typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1,
     autoDensity: true,
     preference: 'webgl',
+    multiView: true,
     width: 1,
     height: 1,
   }).then(() => {
@@ -107,7 +104,6 @@ export function releaseSharedRenderer(): void {
   shared.refCount--
   if (shared.refCount <= 0) {
     for (const vp of shared.viewports.values()) {
-      if (vp.renderTexture) vp.renderTexture.destroy(true)
       vp.stage.destroy({ children: true })
     }
     shared.viewports.clear()
@@ -141,9 +137,7 @@ export function registerViewport(id: string): Viewport {
   const viewport: Viewport = {
     id,
     stage,
-    renderTexture: null,
     canvas: null,
-    ctx: null,
     width: 0,
     height: 0,
     boundary: null,
@@ -173,17 +167,13 @@ export function getViewportBoundary(id: string): EventBoundary | null {
 }
 
 /**
- * Deregister a viewport and free its RenderTexture. The stage Container
- * is destroyed along with its children.
+ * Deregister a viewport. The stage Container is destroyed along with
+ * its children.
  */
 export function deregisterViewport(id: string): void {
   if (!shared) return
   const vp = shared.viewports.get(id)
   if (!vp) return
-  if (vp.renderTexture) {
-    vp.renderTexture.destroy(true)
-    vp.renderTexture = null
-  }
   vp.boundary = null
   vp.stage.destroy({ children: true })
   shared.viewports.delete(id)
@@ -204,38 +194,24 @@ export function bindViewportCanvas(
   if (!vp) return
 
   vp.canvas = canvas
-  vp.ctx = canvas.getContext('2d')
   resizeViewport(id, width, height)
 }
 
 /**
- * Resize a viewport's RenderTexture to match new dimensions.
+ * Resize a viewport's visible canvas backing store to match new dimensions.
  */
 export function resizeViewport(id: string, width: number, height: number): void {
   if (!shared || !shared.ready) return
   const vp = shared.viewports.get(id)
   if (!vp) return
   if (width <= 0 || height <= 0) return
-  if (vp.width === width && vp.height === height && vp.renderTexture) return
+  if (vp.width === width && vp.height === height) return
 
   vp.width = width
   vp.height = height
 
   const resolution = shared.app.renderer.resolution
 
-  // Destroy old render texture
-  if (vp.renderTexture) {
-    vp.renderTexture.destroy(true)
-  }
-
-  // Create new render texture at the viewport's size
-  vp.renderTexture = RenderTexture.create({
-    width: width,
-    height: height,
-    resolution,
-  })
-
-  // Also resize the visible canvas backing store
   if (vp.canvas) {
     vp.canvas.width = Math.round(width * resolution)
     vp.canvas.height = Math.round(height * resolution)
@@ -243,33 +219,20 @@ export function resizeViewport(id: string, width: number, height: number): void 
 }
 
 /**
- * Render a viewport's scene graph to its RenderTexture, then blit to
- * the visible canvas. Called once per viewport per frame from the
- * PixiCanvas draw callback.
+ * Render a viewport's scene graph directly to its visible canvas via
+ * multiView. Called once per viewport per frame from the PixiCanvas
+ * draw callback.
  */
 export function renderViewport(id: string): void {
   if (!shared || !shared.ready) return
   const vp = shared.viewports.get(id)
-  if (!vp || !vp.renderTexture || !vp.canvas || !vp.ctx) return
+  if (!vp || !vp.canvas) return
 
-  const renderer = shared.app.renderer
-
-  // Render the viewport's scene graph into its RenderTexture
-  renderer.render({
+  shared.app.renderer.render({
     container: vp.stage,
-    target: vp.renderTexture,
+    target: vp.canvas,
     clear: true,
   })
-
-  // Extract pixels and blit to the visible canvas.
-  // The renderer's internal canvas holds the last render target's content
-  // after extract. We use extract.canvas() for a direct Canvas2D blit.
-  const pixels = renderer.extract.canvas(vp.renderTexture)
-  if (pixels) {
-    const ctx = vp.ctx
-    ctx.clearRect(0, 0, vp.canvas.width, vp.canvas.height)
-    ctx.drawImage(pixels as CanvasImageSource, 0, 0)
-  }
 }
 
 // ─── Texture helpers ────────────────────────────────────────────────────────

--- a/web/components/agent-visualizer/pixi/pixi-canvas.tsx
+++ b/web/components/agent-visualizer/pixi/pixi-canvas.tsx
@@ -6,11 +6,10 @@
  * Gated behind `?renderer=pixi`. Same prop contract as AgentCanvas so the
  * two are interchangeable in session-canvas-panel.tsx.
  *
- * Uses the shared Pixi renderer (single GL context). Each PixiCanvas
- * instance registers a viewport that owns:
+ * Uses the shared Pixi renderer (single GL context, multiView). Each
+ * PixiCanvas instance registers a viewport that owns:
  *   - A Container (scene-graph subtree with all layers)
- *   - A RenderTexture (off-screen render target)
- *   - A visible <canvas> element (receives blitted pixels each frame)
+ *   - A visible <canvas> element (rendered into directly each frame)
  *
  * Rendering layers (z-order):
  *   background -> edges -> tool-calls -> discoveries -> agents -> bubbles -> particles
@@ -130,7 +129,6 @@ export function PixiCanvas({
         const w = entry.contentRect.width
         const h = entry.contentRect.height
         setDimensions({ width: w, height: h })
-        // Resize the viewport's RenderTexture to match
         resizeViewport(viewportId, w, h)
       }
     })
@@ -424,7 +422,6 @@ export function PixiCanvas({
       worldRef.current = null
       viewportRef.current = null
 
-      // Deregister viewport (frees RenderTexture + stage)
       deregisterViewport(viewportId)
 
       // Release shared renderer (may destroy GL context if last viewport)


### PR DESCRIPTION
Rebases #42 onto current `main`, resolving conflicts with #43 (Pixi hit-test + visibility gating) which landed after #42 was opened.

## Why a new PR

#42's branch was last updated before #43 merged. The diff stat is the same shape as #42 (3 files, ~91/91), but the rebase pulls in PR 43's hit-test surface (`EventBoundary`, `setViewportBoundaryRoot`, `getViewportBoundary`, eventMode=static on entries) so the resulting code keeps both behaviors.

Original PR #42 left untouched for side-by-side review. Close it once this lands.

## What changed vs #42 (only the conflict resolution)

**`web/components/agent-visualizer/pixi/pixi-app.ts`**
- Imports keep `EventBoundary` (from #43) alongside dropping `RenderTexture` (from #42)
- `setViewportBoundaryRoot` / `getViewportBoundary` preserved — they didn't exist when #42 was authored
- `deregisterViewport` body keeps `vp.boundary = null` (from #43); the renderTexture cleanup that #42 originally removed stays removed (the field no longer exists on the Viewport interface)

**`web/components/agent-visualizer/pixi/pixi-app.test.ts`**
- `MockEventBoundary` mock added (matches the EventBoundary import the resolved file now carries)
- All 9 tests already in `main` preserved (incl. #43's `setViewportBoundaryRoot` and `deregisterViewport nulls boundary` tests)
- #42's 4 new tests appended: `multiView: true` init verification + 3 `renderViewport` behavioral tests
- Total: 13 unique tests, no duplicates

**`web/components/agent-visualizer/pixi/pixi-canvas.tsx`**
- Auto-merged cleanly — only docstring edits about multiView replacing the RenderTexture+blit path

## What it does (unchanged from #42)

Closes #35. Migrates from per-viewport `RenderTexture` + `extract.canvas()` + manual Canvas2D `drawImage` to Pixi v8's `multiView` mode. Direct render via `renderer.render({ container, target: visibleCanvas, clear: true })` per viewport, dropping the `readPixels` GPU→CPU sync.

See #42 description for the full caveat about WebGL backend's residual `drawImage` and why this is a partial-but-real win rather than full elimination of pixel copy.

## Verification

- No conflict markers remain
- No orphan references to removed symbols (`renderTexture`, `extract.canvas`)
- Tests not run (rebase worktree had no `node_modules`); resolution is mechanical and TypeScript will catch any remaining issues

Supersedes #42.