### PR TITLE
fix(pixi): close multiView lifecycle bugs surfaced in post-merge review

### DIFF
--- a/web/components/agent-visualizer/pixi/pixi-app.test.ts
+++ b/web/components/agent-visualizer/pixi/pixi-app.test.ts
@@ -9,13 +9,14 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { ApplicationOptions } from 'pixi.js'
 
 // ─── Mock pixi.js ────────────────────────────────────────────────────────
 
 const origCreateElement = document.createElement.bind(document)
 
 let appInstanceCount = 0
-let lastInitOpts: Record<string, unknown> | null = null
+let lastInitOpts: Partial<ApplicationOptions> | null = null
 
 vi.mock('pixi.js', () => {
   class MockContainer {
@@ -66,7 +67,7 @@ vi.mock('pixi.js', () => {
       appInstanceCount++
     }
 
-    async init(opts: Record<string, unknown>) {
+    async init(opts: Partial<ApplicationOptions>) {
       lastInitOpts = opts
     }
 

--- a/web/components/agent-visualizer/pixi/pixi-app.ts
+++ b/web/components/agent-visualizer/pixi/pixi-app.ts
@@ -19,7 +19,7 @@
  * calls sharedRenderer.renderViewport() for its viewport id.
  */
 
-import { Application, Container, EventBoundary, Texture } from 'pixi.js'
+import { Application, Container, EventBoundary, Texture, type WebGLRenderer } from 'pixi.js'
 
 // ─── Viewport registry ─────────────────────────────────────────────────────
 
@@ -40,7 +40,7 @@ export interface Viewport {
 
 /** Singleton state for the shared renderer. */
 interface SharedRendererState {
-  app: Application
+  app: Application<WebGLRenderer>
   viewports: Map<string, Viewport>
   /** Reference count — destroy the app when it drops to 0. */
   refCount: number
@@ -59,14 +59,14 @@ let shared: SharedRendererState | null = null
  * Call `releaseSharedRenderer()` on teardown — when refCount hits 0
  * the Application is destroyed.
  */
-export async function acquireSharedRenderer(): Promise<Application> {
+export async function acquireSharedRenderer(): Promise<Application<WebGLRenderer>> {
   if (shared) {
     shared.refCount++
     if (shared.initPromise) await shared.initPromise
     return shared.app
   }
 
-  const app = new Application()
+  const app = new Application<WebGLRenderer>()
 
   const state: SharedRendererState = {
     app,
@@ -84,6 +84,7 @@ export async function acquireSharedRenderer(): Promise<Application> {
     autoDensity: true,
     preference: 'webgl',
     multiView: true,
+    autoStart: false,
     width: 1,
     height: 1,
   }).then(() => {
@@ -107,6 +108,7 @@ export function releaseSharedRenderer(): void {
       vp.stage.destroy({ children: true })
     }
     shared.viewports.clear()
+    disposeTextureCache()
     shared.app.destroy(true)
     shared = null
   }
@@ -262,7 +264,8 @@ export function getGlowTexture(
   const canvas = document.createElement('canvas')
   canvas.width = size
   canvas.height = size
-  const ctx = canvas.getContext('2d')!
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('getGlowTexture: 2D context unavailable')
   const grad = ctx.createRadialGradient(rQ, rQ, 0, rQ, rQ, rQ)
   const innerHex = innerAlpha.toString(16).padStart(2, '0')
   const outerHex = outerAlpha.toString(16).padStart(2, '0')
@@ -292,7 +295,8 @@ export function getCircleTexture(radius: number): Texture {
   const canvas = document.createElement('canvas')
   canvas.width = size
   canvas.height = size
-  const ctx = canvas.getContext('2d')!
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('getCircleTexture: 2D context unavailable')
   ctx.beginPath()
   ctx.arc(rQ, rQ, rQ, 0, Math.PI * 2)
   ctx.fillStyle = '#ffffff'

--- a/web/components/agent-visualizer/pixi/pixi-canvas.tsx
+++ b/web/components/agent-visualizer/pixi/pixi-canvas.tsx
@@ -16,7 +16,7 @@
  * Bloom post-processing is applied per-viewport as a stage-level filter.
  */
 
-import { useRef, useEffect, useState, useCallback, useMemo, useId } from 'react'
+import { useRef, useEffect, useState, useMemo, useId } from 'react'
 import { Container, EventBoundary } from 'pixi.js'
 import type { SimulationState } from '@/hooks/simulation/types'
 import { useCanvasCamera } from '@/hooks/use-canvas-camera'
@@ -32,7 +32,6 @@ import {
   resizeViewport,
   renderViewport,
   setViewportBoundaryRoot,
-  disposeTextureCache,
 } from './pixi-app'
 import type { Viewport } from './pixi-app'
 import { BackgroundLayer } from './background-layer'
@@ -217,9 +216,11 @@ export function PixiCanvas({
   updateDragLerpRef.current = updateDragLerp
 
   // ─── Draw callback (registered with shared render loop) ─────────────
+  // The render-loop registration reads through drawRef.current, so identity
+  // stability isn't observed downstream — useCallback would be pure overhead.
   const drawRef = useRef<(timestamp: number) => void>(() => {})
 
-  const pixiDraw = useCallback((timestamp: number) => {
+  const pixiDraw = (timestamp: number) => {
     if (!readyRef.current) return
 
     // Skip rendering when the canvas is off-screen (IntersectionObserver).
@@ -302,8 +303,7 @@ export function PixiCanvas({
 
     // Render this viewport via the shared renderer and blit to the visible canvas
     renderViewport(viewportId)
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- layer refs are stable; hook refs kept in sync above
-  }, [simulationRef, transformRef, showHexGrid, selectedToolCallId, selectedDiscoveryId, selectedAgentId, hoveredAgentId, showStats, viewportId])
+  }
 
   drawRef.current = pixiDraw
 
@@ -321,6 +321,11 @@ export function PixiCanvas({
     if (!el || !canvas) return
 
     let destroyed = false
+    // Set true once boot passes the destroyed-check; from that point on
+    // cleanup owns the matching releaseSharedRenderer() call. If cleanup
+    // runs while acquired is still false, boot's own destroyed-check
+    // releases — preventing a double-release on the refCount.
+    let acquired = false
 
     const boot = async () => {
       // Acquire the shared renderer (creates the GL context on first call)
@@ -330,6 +335,8 @@ export function PixiCanvas({
         releaseSharedRenderer()
         return
       }
+
+      acquired = true
 
       // Register this component as a viewport
       const viewport = registerViewport(viewportId)
@@ -422,11 +429,12 @@ export function PixiCanvas({
       worldRef.current = null
       viewportRef.current = null
 
-      deregisterViewport(viewportId)
-
-      // Release shared renderer (may destroy GL context if last viewport)
-      releaseSharedRenderer()
-      disposeTextureCache()
+      // Only deregister + release if boot reached the post-acquire phase.
+      // Otherwise boot's own destroyed-check releases.
+      if (acquired) {
+        deregisterViewport(viewportId)
+        releaseSharedRenderer()
+      }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- bootstrap once
   }, [viewportId])


### PR DESCRIPTION
## Summary

Follow-up to #45. A multi-agent domain review (engineer-pixijs / engineer-react / engineer-typescript / reviewer) caught five issues in the multiView migration after it landed. This PR fixes all five.

### Blockers

- **`disposeTextureCache()` destroyed shared GPU textures on every PixiCanvas unmount**, wiping caches still in use by sibling viewports. Moved the call into `releaseSharedRenderer()` so it runs once when `refCount` hits 0, before `app.destroy(true)`.
- **Async-bootstrap double-release race**: if a `PixiCanvas` unmounted while `await acquireSharedRenderer()` was pending, the cleanup's unconditional `releaseSharedRenderer()` decremented the same `refCount` that boot's destroyed-check then decremented again — `refCount` underflow. Added an `acquired` flag so cleanup only releases when boot has passed the destroyed-check; otherwise boot's own destroyed-check releases.

### Should-fix

- Added `autoStart: false` to `app.init()` — `SimulationManager` owns the rAF, Pixi's internal ticker was redundant.
- Typed `Application` as `Application<WebGLRenderer>` now that `preference: 'webgl'` is fixed, restoring renderer-type narrowing for callers.

### Tightenings

- Replaced `getContext('2d')!` non-null assertions in `getGlowTexture` / `getCircleTexture` with explicit `if (!ctx) throw` guards.
- Typed the test mock's `lastInitOpts` as `Partial<ApplicationOptions>` instead of `Record<string, unknown>`.
- Dropped `useCallback` wrapper around `pixiDraw` — `drawRef.current = pixiDraw` bridges identity, so memoization had no observable effect; long dep array was pure overhead.

## Test plan

- [x] `npx vitest run components/agent-visualizer/pixi/pixi-app.test.ts` → 13/13 pass
- [x] `npm test` (full web suite) → 160/160 pass
- [x] `npx tsc --noEmit` → clean
- [x] Reviewer agent: A+ against the claude-dev-tools:review rubric, no issues
- [ ] Manual smoke: open the visualizer, mount/unmount a PixiCanvas, confirm no console errors and no blank sprites on sibling canvases

🤖 Generated with [Claude Code](https://claude.com/claude-code)