### PR TITLE
feat(perf): frame-rate cap + per-effect toggles in top bar

### DIFF
--- a/web/components/agent-visualizer/index.tsx
+++ b/web/components/agent-visualizer/index.tsx
@@ -31,6 +31,7 @@ import { mergeByTimestamp } from "@/lib/sort-utils"
 import { MessageFeedPanel } from "./message-feed-panel"
 import { TopBar } from "./top-bar"
 import { useAudioEffects } from "@/hooks/use-audio-effects"
+import { usePerfSettings } from "@/hooks/use-perf-settings"
 import { PanelLayoutProvider } from "./panel-layout-provider"
 import { usePanelLayout } from "@/hooks/use-panel-layout"
 
@@ -171,6 +172,14 @@ function AgentVisualizerInner() {
 
   const [isReviewing, setIsReviewing] = useState(false)
   const { isMuted, handleToggleMute, playUiClick } = useAudioEffects(agents, toolCalls, isReviewing)
+
+  // Performance settings: persisted frame-rate cap + per-effect toggles.
+  // The cap is pushed into the shared SimulationManager so the rAF loop
+  // throttles itself; effect toggles flow as props down to PixiCanvas.
+  const { frameCap, setFrameCap, effects, setEffect } = usePerfSettings()
+  useEffect(() => {
+    manager.setFrameCap(frameCap)
+  }, [manager, frameCap])
 
   // Auto-play on mount
   useEffect(() => {
@@ -401,6 +410,7 @@ function AgentVisualizerInner() {
             showStats={showStats}
             showHexGrid={showHexGrid}
             showCostOverlay={showCostOverlay}
+            effects={effects}
             zoomToFitTrigger={zoomToFitTrigger}
             pauseAutoFit={selection.contextMenu !== null}
             getSessionEventLog={bridge.getSessionEventLog}
@@ -530,6 +540,10 @@ function AgentVisualizerInner() {
         onToggleTimeline={() => setShowTimeline(prev => !prev)}
         onToggleMute={handleToggleMute}
         onUiClick={playUiClick}
+        frameCap={frameCap}
+        onFrameCapChange={setFrameCap}
+        effects={effects}
+        onEffectChange={setEffect}
       />
     </div>
     </OpenFileProvider>

--- a/web/components/agent-visualizer/pixi/background-layer.ts
+++ b/web/components/agent-visualizer/pixi/background-layer.ts
@@ -110,6 +110,7 @@ export class BackgroundLayer {
     time: number,
     showHexGrid: boolean,
     activeAgentPos?: { x: number; y: number; color: string },
+    showDepthParticles: boolean = true,
   ): void {
     this.frameCount++
 
@@ -120,7 +121,8 @@ export class BackgroundLayer {
     }
 
     // ── Update depth particles (every other frame for perf) ──────────
-    if (this.frameCount % 2 === 0) {
+    this.particleContainer.visible = showDepthParticles
+    if (showDepthParticles && this.frameCount % 2 === 0) {
       this.updateParticles(dt * 2, width, height, transform)
     }
 

--- a/web/components/agent-visualizer/pixi/pixi-canvas.tsx
+++ b/web/components/agent-visualizer/pixi/pixi-canvas.tsx
@@ -44,6 +44,14 @@ import { ParticlesLayer } from './particles-layer'
 import { PixiBloomFilter } from './bloom-filter'
 import { applyCameraTransform } from './camera'
 import { useSimulationManager } from '../simulation-manager-provider'
+import type { EffectToggles } from '@/hooks/use-perf-settings'
+
+const DEFAULT_EFFECTS: EffectToggles = {
+  bloom: true,
+  particles: true,
+  bubbles: true,
+  backgroundParticles: true,
+}
 
 interface CanvasProps {
   /** Ref to simulation state — read every frame without React re-renders */
@@ -69,6 +77,9 @@ interface CanvasProps {
    *  off-screen. The simulation sub-state keeps ticking so stats panels
    *  still receive fresh data. */
   pauseWhenOffscreen?: boolean
+  /** Per-effect toggles. Disabled effects skip their per-frame update and
+   *  hide their display objects so the GPU can cull the empty subtree. */
+  effects?: EffectToggles
 }
 
 export function PixiCanvas({
@@ -91,6 +102,7 @@ export function PixiCanvas({
   showCostOverlay,
   minZoomLevel,
   pauseWhenOffscreen = true,
+  effects = DEFAULT_EFFECTS,
 }: CanvasProps) {
   const manager = useSimulationManager()
   const containerRef = useRef<HTMLDivElement>(null)
@@ -108,6 +120,8 @@ export function PixiCanvas({
   const boundaryRef = useRef<EventBoundary | null>(null)
   /** Set to true once boot() completes and layers are ready. */
   const readyRef = useRef(false)
+  /** Mirror of readyRef for effect dependencies — refs aren't reactive. */
+  const [booted, setBooted] = useState(false)
   const timeRef = useRef(0)
   const lastFrameRef = useRef(0)
 
@@ -261,6 +275,8 @@ export function PixiCanvas({
       dt,
       timeRef.current,
       showHexGrid,
+      undefined,
+      effects.backgroundParticles,
     )
 
     edgesLayerRef.current?.update(
@@ -291,15 +307,27 @@ export function PixiCanvas({
       timeRef.current,
     )
 
-    bubblesLayerRef.current?.update(s.agents, timeRef.current)
+    // Disabled-effect layers skip their update entirely and hide their
+    // container — saves both the JS update cost and the GPU draw call.
+    if (bubblesLayerRef.current) {
+      bubblesLayerRef.current.container.visible = effects.bubbles
+      if (effects.bubbles) {
+        bubblesLayerRef.current.update(s.agents, timeRef.current)
+      }
+    }
 
-    particlesLayerRef.current?.update(
-      s.particles,
-      s.edges,
-      s.agents,
-      s.toolCalls,
-      timeRef.current,
-    )
+    if (particlesLayerRef.current) {
+      particlesLayerRef.current.container.visible = effects.particles
+      if (effects.particles) {
+        particlesLayerRef.current.update(
+          s.particles,
+          s.edges,
+          s.agents,
+          s.toolCalls,
+          timeRef.current,
+        )
+      }
+    }
 
     // Render this viewport via the shared renderer and blit to the visible canvas
     renderViewport(viewportId)
@@ -378,13 +406,14 @@ export function PixiCanvas({
       particlesLayerRef.current = new ParticlesLayer()
       world.addChild(particlesLayerRef.current.container)
 
-      // Bloom filter — per-viewport post-processing
+      // Bloom filter — per-viewport post-processing. Attached on demand by
+      // the bloom-toggle effect below; we only construct it here.
       const bloomFilter = new PixiBloomFilter(0.6)
-      viewport.stage.filters = [bloomFilter.filter]
       bloomFilterRef.current = bloomFilter
 
       // Signal that the draw callback can start rendering.
       readyRef.current = true
+      setBooted(true)
     }
 
     boot()
@@ -392,6 +421,7 @@ export function PixiCanvas({
     return () => {
       destroyed = true
       readyRef.current = false
+      setBooted(false)
 
       // Dispose layers (before deregisterViewport destroys the stage)
       if (backgroundLayerRef.current) {
@@ -438,6 +468,18 @@ export function PixiCanvas({
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- bootstrap once
   }, [viewportId])
+
+  // ─── Bloom on/off ───────────────────────────────────────────────────────
+  // Attach or detach the bloom post-processing filter as the user toggles
+  // it. Skipping the filter entirely (vs. setting intensity to 0) avoids
+  // the off-screen render-target pass.
+  useEffect(() => {
+    if (!booted) return
+    const viewport = viewportRef.current
+    const bloom = bloomFilterRef.current
+    if (!viewport || !bloom) return
+    viewport.stage.filters = effects.bloom ? [bloom.filter] : []
+  }, [booted, effects.bloom])
 
   return (
     <div

--- a/web/components/agent-visualizer/session-canvas-panel.tsx
+++ b/web/components/agent-visualizer/session-canvas-panel.tsx
@@ -16,6 +16,7 @@ import { FloatingPanel } from './floating-panel'
 import { CanvasZoomControl } from './canvas-zoom-control'
 import { useSessionStatsDispatch, type SessionStats } from './session-stats-provider'
 import { TIMING, type SimulationEvent, type TimelineEvent } from '@/lib/agent-types'
+import type { EffectToggles } from '@/hooks/use-perf-settings'
 
 /** Cached once at module load — true when `?renderer=pixi` is present. */
 const USE_PIXI_RENDERER = typeof window !== 'undefined'
@@ -48,6 +49,7 @@ interface SessionCanvasPanelProps {
   showStats: boolean
   showHexGrid: boolean
   showCostOverlay: boolean
+  effects: EffectToggles
   zoomToFitTrigger: number
   pauseAutoFit: boolean
   getSessionEventLog: (sessionId: string) => readonly SimulationEvent[]
@@ -64,7 +66,7 @@ export function SessionCanvasPanel({
   sessionLabel,
   slot,
   selectedAgentId, hoveredAgentId, selectedToolCallId, selectedDiscoveryId,
-  showStats, showHexGrid, showCostOverlay,
+  showStats, showHexGrid, showCostOverlay, effects,
   zoomToFitTrigger, pauseAutoFit,
   getSessionEventLog,
   onAgentClick, onAgentHover,
@@ -275,6 +277,7 @@ export function SessionCanvasPanel({
               hoveredAgentId={hoveredAgentId}
               showStats={showStats}
               showHexGrid={showHexGrid}
+              effects={effects}
               zoomToFitTrigger={combinedZoomToFitTrigger}
               pauseAutoFit={pauseAutoFit}
               onAgentClick={(id) => onAgentClick(id, sessionId)}

--- a/web/components/agent-visualizer/top-bar.tsx
+++ b/web/components/agent-visualizer/top-bar.tsx
@@ -11,6 +11,7 @@ import { FPSIndicator } from "./fps-indicator"
 import { usePanelLayout } from "@/hooks/use-panel-layout"
 import type { WorkspaceFilterAPI } from "@/hooks/use-workspace-filter"
 import type { SessionInfo, ConnectionStatus } from "@/lib/bridge-types"
+import { FRAME_CAP_OPTIONS, EFFECT_LABELS, type EffectToggles } from "@/hooks/use-perf-settings"
 
 // ─── Mute/Unmute SVG Icons ───────────────────────────────────────────────────
 
@@ -135,6 +136,11 @@ export interface TopBarProps {
   showMessageFeed: boolean
   isMuted: boolean
   workspaceFilter: WorkspaceFilterAPI
+  // Performance settings (frame cap + per-effect toggles)
+  frameCap: number
+  onFrameCapChange: (fps: number) => void
+  effects: EffectToggles
+  onEffectChange: (key: keyof EffectToggles, value: boolean) => void
   /** Session ids whose canvas the user has ✕-closed. The top bar renders a
    *  chip per id so they can be reopened via onShowCanvas. */
   hiddenCanvases?: ReadonlySet<string>
@@ -155,6 +161,7 @@ export const TopBar = memo(function TopBar({
   workspaceFilter,
   hiddenCanvases, onShowCanvas,
   onTogglePanel, onToggleTimeline, onToggleMute, onUiClick,
+  frameCap, onFrameCapChange, effects, onEffectChange,
 }: TopBarProps) {
   const { resetLayout, saveLayout, hardResetLayout, tilePanels, instanceId, hostId, otherInstances } = usePanelLayout()
   const resetClickRef = useRef(0)
@@ -231,6 +238,12 @@ export const TopBar = memo(function TopBar({
 
         {/* Right-side info/controls */}
         <div className="flex items-center gap-4 flex-shrink-0" style={{ color: COLORS.textMuted }}>
+          <PerfButton
+            frameCap={frameCap}
+            onFrameCapChange={onFrameCapChange}
+            effects={effects}
+            onEffectChange={onEffectChange}
+          />
           {isVSCode && <ConnectionIndicator status={connectionStatus} />}
 
           {/* Panel toggle group — kept tightly spaced via inner gap-1, but each
@@ -293,6 +306,133 @@ export const TopBar = memo(function TopBar({
     </FloatingPanel>
   )
 })
+
+// ─── Performance settings button + popover ─────────────────────────────────
+// Frame-rate cap (Off/120/60/30/15) and per-effect toggles. Lowering the cap
+// reduces GPU/CPU load and battery drain without making individual frames
+// faster; turning effects off cuts per-frame work.
+
+function PerfButton({
+  frameCap,
+  onFrameCapChange,
+  effects,
+  onEffectChange,
+}: {
+  frameCap: number
+  onFrameCapChange: (fps: number) => void
+  effects: EffectToggles
+  onEffectChange: (key: keyof EffectToggles, value: boolean) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const buttonRef = useRef<HTMLDivElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+  const [anchorRect, setAnchorRect] = useState<{ top: number; right: number } | null>(null)
+
+  useEffect(() => {
+    if (!open) { setAnchorRect(null); return }
+    const update = () => {
+      const r = buttonRef.current?.getBoundingClientRect()
+      if (r) setAnchorRect({ top: r.bottom + 6, right: window.innerWidth - r.right })
+    }
+    update()
+    window.addEventListener('resize', update)
+    window.addEventListener('scroll', update, true)
+    return () => {
+      window.removeEventListener('resize', update)
+      window.removeEventListener('scroll', update, true)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (buttonRef.current?.contains(target)) return
+      if (popoverRef.current?.contains(target)) return
+      setOpen(false)
+    }
+    window.addEventListener('mousedown', handler)
+    return () => window.removeEventListener('mousedown', handler)
+  }, [open])
+
+  const offCount = Object.values(effects).filter(v => !v).length
+  const capLabel = FRAME_CAP_OPTIONS.find(o => o.value === frameCap)?.label ?? 'Uncapped'
+  const summary = offCount > 0
+    ? `Perf · ${capLabel} · ${offCount} off`
+    : `Perf · ${capLabel}`
+
+  const popoverContent = (
+    <div
+      ref={popoverRef}
+      style={{
+        position: 'fixed',
+        top: anchorRect?.top ?? 0,
+        right: anchorRect?.right ?? 0,
+        minWidth: 260,
+        padding: 10,
+        background: COLORS.panelBg,
+        border: `1px solid ${COLORS.glassBorder}`,
+        borderRadius: 6,
+        boxShadow: '0 8px 24px rgba(0,0,0,0.5)',
+        zIndex: 99999,
+        backdropFilter: 'blur(20px)',
+        WebkitBackdropFilter: 'blur(20px)',
+      }}
+    >
+      <div className="text-[10px] font-mono mb-2" style={{ color: COLORS.textMuted, letterSpacing: '0.08em' }}>
+        FRAME CAP
+      </div>
+      <select
+        value={frameCap}
+        onChange={(e) => onFrameCapChange(Number(e.target.value))}
+        className="w-full font-mono text-[11px] px-2 py-1 rounded mb-3"
+        style={{
+          background: COLORS.toggleInactive,
+          border: `1px solid ${COLORS.toggleBorder}`,
+          color: COLORS.textPrimary,
+          cursor: 'pointer',
+        }}
+      >
+        {FRAME_CAP_OPTIONS.map(opt => (
+          <option key={opt.value} value={opt.value}>{opt.label}</option>
+        ))}
+      </select>
+
+      <div className="text-[10px] font-mono mb-1" style={{ color: COLORS.textMuted, letterSpacing: '0.08em' }}>
+        EFFECTS
+      </div>
+      {(Object.keys(EFFECT_LABELS) as Array<keyof EffectToggles>).map(key => (
+        <label
+          key={key}
+          className="flex items-center gap-2 py-1 px-1 rounded cursor-pointer"
+          style={{ color: effects[key] ? COLORS.textPrimary : COLORS.textMuted }}
+        >
+          <input
+            type="checkbox"
+            checked={effects[key]}
+            onChange={(e) => onEffectChange(key, e.target.checked)}
+            style={{ accentColor: COLORS.holoBase, cursor: 'pointer' }}
+          />
+          <span className="text-[10px] font-mono">{EFFECT_LABELS[key]}</span>
+        </label>
+      ))}
+      <div className="text-[9px] font-mono mt-2 pt-2" style={{ color: COLORS.textMuted, borderTop: `1px solid ${COLORS.holoBorder06}` }}>
+        Lower cap saves power; turning effects off cuts per-frame work.
+      </div>
+    </div>
+  )
+
+  return (
+    <>
+      <div ref={buttonRef} style={{ display: 'inline-flex' }}>
+        <ToggleButton active={frameCap > 0 || offCount > 0} onClick={() => setOpen(o => !o)}>
+          {summary}
+        </ToggleButton>
+      </div>
+      {open && anchorRect && typeof document !== 'undefined' && createPortal(popoverContent, document.body)}
+    </>
+  )
+}
 
 // ─── Workspace filter button + popover ──────────────────────────────────────
 

--- a/web/hooks/use-perf-settings.ts
+++ b/web/hooks/use-perf-settings.ts
@@ -1,0 +1,64 @@
+'use client'
+
+import { useCallback } from 'react'
+import { usePersistedState } from './use-persisted-state'
+
+// ─── Frame cap ──────────────────────────────────────────────────────────────
+// `0` means "uncapped" (let rAF run at the display refresh rate).
+export const FRAME_CAP_OPTIONS: ReadonlyArray<{ value: number; label: string }> = [
+  { value: 0,   label: 'Uncapped' },
+  { value: 120, label: '120 FPS' },
+  { value: 60,  label: '60 FPS' },
+  { value: 30,  label: '30 FPS' },
+  { value: 15,  label: '15 FPS' },
+]
+
+// ─── Effects ────────────────────────────────────────────────────────────────
+// Each toggle controls one rendering feature that can be disabled to reduce
+// per-frame GPU/CPU cost. Defaults are "everything on" — matches current
+// behavior so users opt in to a perf trade rather than discovering missing
+// effects after upgrading.
+export interface EffectToggles {
+  bloom: boolean
+  particles: boolean
+  bubbles: boolean
+  backgroundParticles: boolean
+}
+
+const DEFAULT_EFFECTS: EffectToggles = {
+  bloom: true,
+  particles: true,
+  bubbles: true,
+  backgroundParticles: true,
+}
+
+export const EFFECT_LABELS: Record<keyof EffectToggles, string> = {
+  bloom: 'Bloom (post-processing glow)',
+  particles: 'Particle trails',
+  bubbles: 'Message bubbles',
+  backgroundParticles: 'Background depth particles',
+}
+
+export function usePerfSettings() {
+  const [frameCap, setFrameCap] = usePersistedState<number>(
+    'agent-flow:frame-cap:v1',
+    0,
+  )
+  const [effects, setEffects] = usePersistedState<EffectToggles>(
+    'agent-flow:effects:v1',
+    DEFAULT_EFFECTS,
+  )
+
+  // Tolerate older persisted shapes by merging with defaults — adding a new
+  // toggle later shouldn't blank out the saved value for the existing ones.
+  const safeEffects: EffectToggles = { ...DEFAULT_EFFECTS, ...effects }
+
+  const setEffect = useCallback(
+    (key: keyof EffectToggles, value: boolean) => {
+      setEffects(prev => ({ ...DEFAULT_EFFECTS, ...prev, [key]: value }))
+    },
+    [setEffects],
+  )
+
+  return { frameCap, setFrameCap, effects: safeEffects, setEffect }
+}

--- a/web/lib/simulation-manager.ts
+++ b/web/lib/simulation-manager.ts
@@ -124,6 +124,14 @@ export interface SimulationManager {
    *  order. */
   registerRender(callback: RenderCallback): () => void
 
+  // ── Frame cap ───────────────────────────────────────────────────────────
+  /** Cap the rendering frame rate. Pass `null` (or 0) for "uncapped" — let
+   *  rAF run at the display refresh rate. A non-zero cap throttles the loop
+   *  by skipping rAF callbacks until the per-frame budget has elapsed.
+   *  Simulation deltas are still derived from real elapsed time, so motion
+   *  speed is preserved. */
+  setFrameCap(fps: number | null): void
+
   // ── Subscriptions (useSyncExternalStore compatible) ──────────────────────
   /** Subscribe to changes for a specific session. The listener fires when
    *  structural state changes (new events processed), not every frame. */
@@ -151,6 +159,10 @@ export function createSimulationManager(): SimulationManager {
   let rafId = 0
   let lastTimestamp = 0
   let running = false
+  /** User-selected frame cap in fps (e.g. 30, 60). 0/null = uncapped. */
+  let frameCapFps = 0
+  /** Timestamp (rAF) at which the most recent rendered frame was emitted. */
+  let lastRenderedTimestamp = 0
 
   // ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -444,12 +456,26 @@ export function createSimulationManager(): SimulationManager {
       return
     }
 
+    // User-selected frame cap. We compare against the most recently rendered
+    // timestamp (not lastTimestamp, which advances even on skipped frames in
+    // the gate above) so the cap reflects actual emitted frames. We allow a
+    // small slack so a 60 Hz monitor can still hit a 60-fps cap when the rAF
+    // callback fires a hair early.
+    if (frameCapFps > 0 && lastRenderedTimestamp) {
+      const minInterval = 1000 / frameCapFps - 1
+      if (timestamp - lastRenderedTimestamp < minInterval) {
+        rafId = requestAnimationFrame(loop)
+        return
+      }
+    }
+
     if (!lastTimestamp) lastTimestamp = timestamp
     const deltaTime = Math.min(
       (timestamp - lastTimestamp) / 1000,
       ANIM_SPEED.maxDeltaTime,
     )
     lastTimestamp = timestamp
+    lastRenderedTimestamp = timestamp
 
     for (const [sessionId, sub] of sessions) {
       tickSession(sessionId, sub, timestamp, deltaTime)
@@ -707,6 +733,13 @@ export function createSimulationManager(): SimulationManager {
         const idx = renderCallbacks.indexOf(callback)
         if (idx >= 0) renderCallbacks.splice(idx, 1)
       }
+    },
+
+    setFrameCap(fps) {
+      frameCapFps = fps && fps > 0 ? fps : 0
+      // Reset so the next frame renders immediately rather than waiting out
+      // a stale interval measured against the old cap.
+      lastRenderedTimestamp = 0
     },
 
     subscribe(sessionId, listener) {


### PR DESCRIPTION
## Summary
- Adds a **Perf** popover to the top bar (next to FPS readout) with a frame-rate cap (Uncapped / 120 / 60 / 30 / 15) and per-effect on/off toggles for bloom, particle trails, message bubbles, and background depth particles.
- Frame cap throttles the shared rAF loop in `simulation-manager.ts`. Disabled effects skip both `update()` and draw; bloom detaches the post-processing filter so the off-screen render-target pass is skipped entirely.
- Settings persist via existing `usePersistedState` (`agent-flow:frame-cap:v1`, `agent-flow:effects:v1`). Default is **Uncapped + all effects on** — matches current behavior.

## Notes
- A cap saves CPU/GPU/battery but does not make individual frames cheaper. If a viewer is already missing 60 FPS, capping at 30 just halves the wasted attempts — the per-frame bottleneck is unchanged.
- Of the toggles, **bloom** is the largest single GPU win, **particles** the largest CPU win.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 160/160 pass
- [x] `pnpm build` clean
- [ ] Manual: open Perf popover, toggle each effect, verify visual change in canvas
- [ ] Manual: set 30 FPS cap, confirm FPS indicator settles near 30
- [ ] Manual: reload page, confirm settings persist
- [ ] Manual: switch caps rapidly — no stuck frames or jank when raising the cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)