### PR TITLE
fix(perf): remove hardcoded 60fps gate that masked the user-selectable frame cap

### DIFF
--- a/web/lib/canvas-constants.ts
+++ b/web/lib/canvas-constants.ts
@@ -94,8 +94,6 @@ export const ANIM_SPEED = {
   maxDeltaTime: 0.1,
   /** Default delta time when time info unavailable */
   defaultDeltaTime: 0.016,
-  /** Minimum ms between frames (60fps cap, with 1ms slack for timing jitter) */
-  minFrameInterval: (1000 / 60) - 1,
 } as const
 
 // ─── UI panel constants ─────────────────────────────────────────────────────

--- a/web/lib/simulation-manager.ts
+++ b/web/lib/simulation-manager.ts
@@ -450,17 +450,9 @@ export function createSimulationManager(): SimulationManager {
   function loop(timestamp: number): void {
     if (!running) return
 
-    const elapsed = timestamp - lastTimestamp
-    if (lastTimestamp && elapsed < ANIM_SPEED.minFrameInterval) {
-      rafId = requestAnimationFrame(loop)
-      return
-    }
-
-    // User-selected frame cap. We compare against the most recently rendered
-    // timestamp (not lastTimestamp, which advances even on skipped frames in
-    // the gate above) so the cap reflects actual emitted frames. We allow a
-    // small slack so a 60 Hz monitor can still hit a 60-fps cap when the rAF
-    // callback fires a hair early.
+    // User-selected frame cap. A small slack lets a 60 Hz monitor still hit
+    // a 60-fps cap when the rAF callback fires a hair early. With cap == 0
+    // (Uncapped) the loop runs at the display refresh rate.
     if (frameCapFps > 0 && lastRenderedTimestamp) {
       const minInterval = 1000 / frameCapFps - 1
       if (timestamp - lastRenderedTimestamp < minInterval) {


### PR DESCRIPTION
## Summary

Follow-up to #49. The Perf popover's frame-cap dropdown wired through to \`manager.setFrameCap()\` correctly, but a separate hardcoded gate in the rAF loop — \`elapsed < ANIM_SPEED.minFrameInterval\` where \`minFrameInterval = (1000/60) - 1\` — was already skipping any frame faster than ~60fps, regardless of the user's selection.

Symptoms:
- **Uncapped / 120 FPS** → still 60fps. Cap "did nothing".
- **60 FPS** → 60fps. Coincidentally matched, looked correct.
- **30 / 15 FPS** → did work (those caps are below the hardcoded gate).

This drops the hardcoded gate (and the now-unused \`ANIM_SPEED.minFrameInterval\` constant). The user-selectable cap is now the only throttle; "Uncapped" runs at the display refresh rate.

## Test plan

- [x] \`npm test\` (full web suite) — 160/160 pass
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual: pick "Uncapped" on a >60Hz display; FPS readout should rise above 60. Pick "120 FPS"; should hit ~120 on a ≥120Hz display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)