### PR TITLE
fix(pixi): unblock WebGL renderer (bloom shader + glyph upload + bench flag)

### DIFF
--- a/bench/run-bench.mjs
+++ b/bench/run-bench.mjs
@@ -57,6 +57,7 @@ let WARMUP_MS = 30_000
 let MEASURE_MS = 90_000
 let STACK_FILTER = null  // CLI: --stack A-base — limit to one stack
 let SIM_COUNT = 3        // concurrent sessions in the sim ('concurrent' scenario)
+let RENDERER = null      // CLI: --renderer pixi — opt into the WebGL canvas. Default = unset = Canvas2D.
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -158,7 +159,10 @@ async function runOnce({ stack, throttle, rep, browser }) {
 
   // Per-tab CDP throttle. Set after navigate so initial bundle parse is unthrottled
   // — we measure the steady-state, not first paint.
-  await page.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: 'load' })
+  const url = RENDERER
+    ? `http://127.0.0.1:${PORT}/?renderer=${encodeURIComponent(RENDERER)}`
+    : `http://127.0.0.1:${PORT}/`
+  await page.goto(url, { waitUntil: 'load' })
 
   // PR 1 (and any branch with the workspace filter) defaults previously-unseen
   // workspaces to HIDDEN. Without this, the bench workspace is filtered out and
@@ -225,6 +229,7 @@ async function runOnce({ stack, throttle, rep, browser }) {
     throttle,
     simCount: SIM_COUNT,
     rep,
+    renderer: RENDERER ?? 'canvas2d',
     metrics: summary,
     cdp: {
       scriptDurationSec: cdpDelta('ScriptDuration'),
@@ -376,6 +381,7 @@ function parseCliArgs(argv) {
     else if (a === '--no-throttle') THROTTLES = [1]
     else if (a === '--throttle-only') THROTTLES = [4]
     else if (a === '--sim-count' && argv[i + 1]) { SIM_COUNT = parseInt(argv[++i], 10) }
+    else if (a === '--renderer' && argv[i + 1]) { RENDERER = argv[++i] }
   }
   return out
 }

--- a/web/components/agent-visualizer/pixi/bloom-filter.ts
+++ b/web/components/agent-visualizer/pixi/bloom-filter.ts
@@ -24,7 +24,9 @@ import { Filter, GlProgram } from 'pixi.js'
 
 // ── Vertex shader ───────────────────────────────────────────────────────
 // Standard passthrough -- Filter provides the projection + position.
-const VERTEX = `
+// `#version 300 es` opts into ES 3.00 syntax (in/out, texture()) — without it
+// Pixi v8 falls back to ES 1.00 emulation and this shader fails to compile.
+const VERTEX = `#version 300 es
 in vec2 aPosition;
 out vec2 vTextureCoord;
 
@@ -53,7 +55,7 @@ void main(void)
 `
 
 // ── Fragment shader ─────────────────────────────────────────────────────
-const FRAGMENT = `
+const FRAGMENT = `#version 300 es
 in vec2 vTextureCoord;
 out vec4 finalColor;
 

--- a/web/components/agent-visualizer/pixi/glyph-atlas.test.ts
+++ b/web/components/agent-visualizer/pixi/glyph-atlas.test.ts
@@ -42,7 +42,9 @@ vi.mock('pixi.js', () => {
 
   class MockTextureSource {
     _id: number
+    updateCount = 0
     constructor() { this._id = textureIdCounter++ }
+    update() { this.updateCount++ }
   }
 
   class MockTexture {

--- a/web/components/agent-visualizer/pixi/glyph-atlas.ts
+++ b/web/components/agent-visualizer/pixi/glyph-atlas.ts
@@ -92,6 +92,10 @@ export class GlyphAtlas {
     page.ctx.fillStyle = color
     page.ctx.fillText(text, x + ATLAS_PADDING, y + ATLAS_PADDING)
 
+    // Tell Pixi the underlying canvas changed so the GPU texture re-uploads.
+    // Without this, only the glyph baked before the first GPU sample is visible.
+    page.baseTexture.source.update()
+
     // Advance cursor
     page.cursorX += w
     page.rowHeight = Math.max(page.rowHeight, h)


### PR DESCRIPTION
## Summary

Three bugs surfaced when actually exercising \`?renderer=pixi\` for the first time. The bench harness navigates without the query param (always Canvas2D), so the Pixi path had never been end-to-end validated and these defects shipped silently with #45.

### 1) \`bloom-filter.ts\` — shader fails to compile

Symptom: \`PixiJS Error: Could not initialize shader\` thrown from \`pixi-app.ts:233\` (the \`renderer.render\` call). With bloom toggled off, the canvas renders.

Cause: the bloom GLSL uses ES 3.00 syntax (\`in\` / \`out\` / \`texture()\` / \`finalColor\`) but omits \`#version 300 es\`. Pixi v8's \`GlProgram\` detects the absent directive and applies an ES 1.00 compatibility-define rewrite which doesn't satisfy this shader's actual grammar (specifically, the explicit \`out vec4 finalColor;\` declaration combined with custom uniforms).

Fix: prepend \`#version 300 es\` to both \`VERTEX\` and \`FRAGMENT\` strings — opts into native ES 3.00 compilation, no rewrite.

### 2) \`glyph-atlas.ts\` — only the first glyph renders

Symptom: only one piece of text ("orchestrator") is visible on the canvas; subsequent agent labels stay blank.

Cause: Pixi v8's \`CanvasSource\` is not auto-updated when its backing canvas is mutated after the Texture is constructed. The atlas allocates an empty canvas, builds a Texture wrapping it, then \`fillText()\`s glyphs into the canvas — but the GPU upload only happens once (eagerly, on the first sample). All subsequent fillText writes land on the canvas but never reach the GPU.

Fix: call \`page.baseTexture.source.update()\` after each \`fillText()\`. \`TextureSource.update()\`'s docstring is literally *"call this if you have modified the texture outside of the constructor"*.

### 3) \`bench/run-bench.mjs\` — \`--renderer\` flag

The harness's \`page.goto\` was hardcoded to \`http://127.0.0.1:PORT/\` with no query param, so every bench result is a Canvas2D measurement — regardless of which renderer was the perf focus of the change being measured. The multiView migration (#45) and the lifecycle fixes (#47) registered as zero on the bench numbers because Pixi was never instantiated.

This adds:
- \`--renderer pixi\` flag, append \`?renderer=pixi\` to the goto URL when set.
- \`renderer\` field in each \`runs.jsonl\` row so summaries don't conflate Canvas2D and Pixi cells.

Default unchanged (Canvas2D) so existing scripts keep working.

## Test plan

- [x] \`npm test\` (full web suite) — 160/160 pass
- [x] \`npx tsc --noEmit\` — clean
- [x] Glyph-atlas test mock updated to expose \`update()\` on \`MockTextureSource\`
- [ ] Manual: load \`/?renderer=pixi\` with bloom enabled — canvas renders, no shader error in the console
- [ ] Manual: spawn multiple agents — every agent label visible (not just the first)
- [ ] Manual: \`cd bench && node run-bench.mjs --smoke --stack C-pr1 --renderer pixi\` — bench completes without error and the resulting JSONL row shows \`"renderer": "pixi"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)