### PR TITLE
feat(perf-popover): hide effect toggles on Canvas2D, keep frame-cap

### DIFF
--- a/web/components/agent-visualizer/session-canvas-panel.tsx
+++ b/web/components/agent-visualizer/session-canvas-panel.tsx
@@ -18,9 +18,7 @@ import { useSessionStatsDispatch, type SessionStats } from './session-stats-prov
 import { TIMING, type SimulationEvent, type TimelineEvent } from '@/lib/agent-types'
 import type { EffectToggles } from '@/hooks/use-perf-settings'
 
-/** Cached once at module load — true when `?renderer=pixi` is present. */
-const USE_PIXI_RENDERER = typeof window !== 'undefined'
-  && new URLSearchParams(window.location.search).get('renderer') === 'pixi'
+import { IS_PIXI_RENDERER as USE_PIXI_RENDERER } from '@/lib/renderer-mode'
 
 /** Stable empty-events sentinel — keeps the externalEvents prop reference
  *  identical across idle renders so useAgentSimulation's animate callback

--- a/web/components/agent-visualizer/top-bar.tsx
+++ b/web/components/agent-visualizer/top-bar.tsx
@@ -12,6 +12,7 @@ import { usePanelLayout } from "@/hooks/use-panel-layout"
 import type { WorkspaceFilterAPI } from "@/hooks/use-workspace-filter"
 import type { SessionInfo, ConnectionStatus } from "@/lib/bridge-types"
 import { FRAME_CAP_OPTIONS, EFFECT_LABELS, type EffectToggles } from "@/hooks/use-perf-settings"
+import { IS_PIXI_RENDERER } from "@/lib/renderer-mode"
 
 // ─── Mute/Unmute SVG Icons ───────────────────────────────────────────────────
 
@@ -355,7 +356,10 @@ function PerfButton({
     return () => window.removeEventListener('mousedown', handler)
   }, [open])
 
-  const offCount = Object.values(effects).filter(v => !v).length
+  // Effect toggles only flow into the Pixi renderer; on Canvas2D they're
+  // visible in the UI but no-ops, so we hide them entirely off the Pixi path.
+  const showEffects = IS_PIXI_RENDERER
+  const offCount = showEffects ? Object.values(effects).filter(v => !v).length : 0
   const capLabel = FRAME_CAP_OPTIONS.find(o => o.value === frameCap)?.label ?? 'Uncapped'
   const summary = offCount > 0
     ? `Perf · ${capLabel} · ${offCount} off`
@@ -398,26 +402,32 @@ function PerfButton({
         ))}
       </select>
 
-      <div className="text-[10px] font-mono mb-1" style={{ color: COLORS.textMuted, letterSpacing: '0.08em' }}>
-        EFFECTS
-      </div>
-      {(Object.keys(EFFECT_LABELS) as Array<keyof EffectToggles>).map(key => (
-        <label
-          key={key}
-          className="flex items-center gap-2 py-1 px-1 rounded cursor-pointer"
-          style={{ color: effects[key] ? COLORS.textPrimary : COLORS.textMuted }}
-        >
-          <input
-            type="checkbox"
-            checked={effects[key]}
-            onChange={(e) => onEffectChange(key, e.target.checked)}
-            style={{ accentColor: COLORS.holoBase, cursor: 'pointer' }}
-          />
-          <span className="text-[10px] font-mono">{EFFECT_LABELS[key]}</span>
-        </label>
-      ))}
+      {showEffects && (
+        <>
+          <div className="text-[10px] font-mono mb-1" style={{ color: COLORS.textMuted, letterSpacing: '0.08em' }}>
+            EFFECTS
+          </div>
+          {(Object.keys(EFFECT_LABELS) as Array<keyof EffectToggles>).map(key => (
+            <label
+              key={key}
+              className="flex items-center gap-2 py-1 px-1 rounded cursor-pointer"
+              style={{ color: effects[key] ? COLORS.textPrimary : COLORS.textMuted }}
+            >
+              <input
+                type="checkbox"
+                checked={effects[key]}
+                onChange={(e) => onEffectChange(key, e.target.checked)}
+                style={{ accentColor: COLORS.holoBase, cursor: 'pointer' }}
+              />
+              <span className="text-[10px] font-mono">{EFFECT_LABELS[key]}</span>
+            </label>
+          ))}
+        </>
+      )}
       <div className="text-[9px] font-mono mt-2 pt-2" style={{ color: COLORS.textMuted, borderTop: `1px solid ${COLORS.holoBorder06}` }}>
-        Lower cap saves power; turning effects off cuts per-frame work.
+        {showEffects
+          ? 'Lower cap saves power; turning effects off cuts per-frame work.'
+          : 'Lower cap saves power. (Effect toggles only apply on the WebGL renderer.)'}
       </div>
     </div>
   )

--- a/web/lib/renderer-mode.ts
+++ b/web/lib/renderer-mode.ts
@@ -1,0 +1,12 @@
+/**
+ * Detect which canvas renderer is active for this page load.
+ *
+ * Cached at module load: `?renderer=pixi` opts into the WebGL renderer,
+ * anything else (no param, or `?renderer=canvas2d`) stays on the default
+ * Canvas2D path.
+ *
+ * UI gates use this to hide controls that only meaningfully affect one
+ * renderer (e.g. effect toggles flow into PixiCanvas only).
+ */
+export const IS_PIXI_RENDERER = typeof window !== 'undefined'
+  && new URLSearchParams(window.location.search).get('renderer') === 'pixi'


### PR DESCRIPTION
## Summary

Removes the misleading-on-Canvas2D bits of the Perf popover, leaves what works.

- **Effect toggles** (bloom / particles / bubbles / backgroundParticles) — only flow into \`PixiCanvas\`, no-op on Canvas2D. **Hidden** when \`?renderer=pixi\` is not set.
- **Frame-cap dropdown** — lives in \`simulation-manager\` (shared between renderers), works on both. **Stays.**

Lifts the renderer-detection const out of \`session-canvas-panel.tsx\` into \`web/lib/renderer-mode.ts\` so \`top-bar.tsx\` can read the same value without duplicating the URL-param check. Footer copy in the popover also adjusts to match.

## Test plan

- [x] \`npm test\` (full web suite) — 160/160 pass
- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual on default URL: open Perf popover; only Frame-cap section visible.
- [ ] Manual on \`?renderer=pixi\`: open Perf popover; both Frame-cap and Effects sections visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)