### PR TITLE
perf: cut multi-canvas React commits ~50% (shared ticker + panel memo)

### DIFF
--- a/web/components/agent-visualizer/index.tsx
+++ b/web/components/agent-visualizer/index.tsx
@@ -409,7 +409,7 @@ function AgentVisualizerInner() {
             onContextMenu={selection.handleContextMenu}
             onToolCallClick={selection.handleToolCallClick}
             onDiscoveryClick={selection.handleDiscoveryClick}
-            onClose={() => hideCanvas(session.id)}
+            onClose={hideCanvas}
           />
         )
       })}

--- a/web/components/agent-visualizer/session-canvas-panel.tsx
+++ b/web/components/agent-visualizer/session-canvas-panel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSessionSimulation } from '@/hooks/use-session-simulation'
 import { useSimulationManager } from './simulation-manager-provider'
 import { useFrameRefSelector } from '@/hooks/use-frame-ref-selector'
@@ -56,10 +56,12 @@ interface SessionCanvasPanelProps {
   onContextMenu: (e: React.MouseEvent, type: 'agent' | 'edge' | 'canvas', id?: string) => void
   onToolCallClick?: (toolCallId: string | null) => void
   onDiscoveryClick?: (discoveryId: string | null) => void
-  onClose?: () => void
+  /** Called with the panel's sessionId so the parent can use one stable
+   *  callback instead of allocating a new arrow per panel per render. */
+  onClose?: (sessionId: string) => void
 }
 
-export function SessionCanvasPanel({
+function SessionCanvasPanelImpl({
   sessionId,
   sessionLabel,
   slot,
@@ -88,6 +90,10 @@ export function SessionCanvasPanel({
   useEffect(() => {
     sim.play()
   }, [sim.play])
+
+  // Stabilize the FloatingPanel close callback so React.memo on this
+  // component isn't defeated by parents passing a fresh arrow each render.
+  const handleClose = useCallback(() => onClose?.(sessionId), [onClose, sessionId])
 
   const { setSessionStats, removeSessionStats } = useSessionStatsDispatch()
 
@@ -262,7 +268,7 @@ export function SessionCanvasPanel({
       title={displayTitle}
       accentColor={sessionColor.accent}
       onTitleEdit={(next) => setName(sessionId, next)}
-      onClose={onClose}
+      onClose={onClose ? handleClose : undefined}
       noContentZoom
     >
       <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', background: sessionColor.tint }}>
@@ -331,3 +337,11 @@ export function SessionCanvasPanel({
     </FloatingPanel>
   )
 }
+
+// React.memo so SSE event-version bumps in the parent (which fan out to
+// every panel via setEventVersion → AgentVisualizerInner re-render) don't
+// re-render panels whose props haven't actually changed. The relevant
+// changes for any one panel are: its own session's events (consumed via
+// the externalEvents pipeline inside the impl), selection state, panel
+// toggles, and resize triggers. All other parent re-renders should skip.
+export const SessionCanvasPanel = memo(SessionCanvasPanelImpl)

--- a/web/hooks/use-frame-ref-selector.test.ts
+++ b/web/hooks/use-frame-ref-selector.test.ts
@@ -87,4 +87,37 @@ describe('useFrameRefSelector', () => {
 
     expect(renderCount.value).toBeGreaterThan(afterInit)
   })
+
+  it('mounts N selectors but registers only one shared timer', () => {
+    // Regression guard for the multi-canvas perf fix: 12 selectors used to
+    // create 12 setIntervals (3 canvases × 4 selectors each), clustering
+    // wakeups into long-task fragments under CPU throttle. The shared
+    // ticker collapses them into a single setInterval.
+    const setIntervalSpy = vi.spyOn(global, 'setInterval')
+    const initialCalls = setIntervalSpy.mock.calls.length
+
+    const state = createEmptyState({ currentTime: 1, isPlaying: true })
+    const ref = { current: state }
+
+    const hooks = [
+      renderHook(() => useFrameRefSelector(ref, (s) => s.currentTime)),
+      renderHook(() => useFrameRefSelector(ref, (s) => s.isPlaying)),
+      renderHook(() => useFrameRefSelector(ref, (s) => s.speed)),
+      renderHook(() => useFrameRefSelector(ref, (s) => s.maxTime)),
+    ]
+
+    // 4 selectors mounted — only ONE additional setInterval should have fired.
+    expect(setIntervalSpy.mock.calls.length - initialCalls).toBe(1)
+
+    // Mounting more selectors must not allocate further intervals.
+    const more = [
+      renderHook(() => useFrameRefSelector(ref, (s) => s.currentTime)),
+      renderHook(() => useFrameRefSelector(ref, (s) => s.isPlaying)),
+    ]
+    expect(setIntervalSpy.mock.calls.length - initialCalls).toBe(1)
+
+    // Cleanup so the shared ticker doesn't leak across tests.
+    for (const h of [...hooks, ...more]) h.unmount()
+    setIntervalSpy.mockRestore()
+  })
 })

--- a/web/hooks/use-frame-ref-selector.test.ts
+++ b/web/hooks/use-frame-ref-selector.test.ts
@@ -103,7 +103,7 @@ describe('useFrameRefSelector', () => {
       renderHook(() => useFrameRefSelector(ref, (s) => s.currentTime)),
       renderHook(() => useFrameRefSelector(ref, (s) => s.isPlaying)),
       renderHook(() => useFrameRefSelector(ref, (s) => s.speed)),
-      renderHook(() => useFrameRefSelector(ref, (s) => s.maxTime)),
+      renderHook(() => useFrameRefSelector(ref, (s) => s.maxTimeReached)),
     ]
 
     // 4 selectors mounted — only ONE additional setInterval should have fired.

--- a/web/hooks/use-frame-ref-selector.ts
+++ b/web/hooks/use-frame-ref-selector.ts
@@ -8,6 +8,28 @@ import type { SimulationState } from './simulation/types'
  */
 const POLL_INTERVAL_MS = 250
 
+// Shared 4 Hz ticker — one setInterval drives every useFrameRefSelector
+// instance in the app. With N session canvases each instantiating M selectors,
+// the previous design ran N*M independent setIntervals — under CPU throttle
+// these cluster into long-task fragments. A single shared timer fans out to
+// all subscribers in O(N*M) per tick, but only one wakeup per period.
+const subscribers = new Set<() => void>()
+let intervalId: ReturnType<typeof setInterval> | null = null
+
+function ensureTicker() {
+  if (intervalId !== null) return
+  intervalId = setInterval(() => {
+    for (const tick of subscribers) tick()
+  }, POLL_INTERVAL_MS)
+}
+
+function stopTickerIfEmpty() {
+  if (subscribers.size === 0 && intervalId !== null) {
+    clearInterval(intervalId)
+    intervalId = null
+  }
+}
+
 /**
  * Subscribe to a slice of a MutableRefObject<SimulationState> without
  * coupling to React re-renders of the simulation hook. The selector runs
@@ -21,22 +43,26 @@ export function useFrameRefSelector<T>(
   frameRef: React.RefObject<SimulationState>,
   selector: (state: SimulationState) => T,
 ): T {
-  // Mutable snapshot that the external store reads from. Updated by a
-  // polling interval that compares the ref's current value against the
-  // cached selection.
+  // Mutable snapshot that the external store reads from. Updated by the
+  // shared ticker that compares the ref's current value against the cached
+  // selection.
   const cachedRef = useRef<T>(selector(frameRef.current))
   const listenersRef = useRef(new Set<() => void>())
 
-  // Polling timer: reads frameRef, runs selector, emits if changed.
   useEffect(() => {
-    const id = setInterval(() => {
+    const tick = () => {
       const next = selector(frameRef.current)
       if (!Object.is(next, cachedRef.current)) {
         cachedRef.current = next
         for (const l of listenersRef.current) l()
       }
-    }, POLL_INTERVAL_MS)
-    return () => clearInterval(id)
+    }
+    subscribers.add(tick)
+    ensureTicker()
+    return () => {
+      subscribers.delete(tick)
+      stopTickerIfEmpty()
+    }
   }, [frameRef, selector])
 
   const subscribe = useCallback((listener: () => void) => {


### PR DESCRIPTION
Two cheap wins from the multi-canvas perf investigation in #50. Together they cut React commits in the workload-matched (3-canvas) bench by **~50%** while preserving correctness.

> Long-task blocking time at 4× throttle is **not** moved by these fixes (~81s before and after). That confirms the long-task culprit is in the render path, not in React. To be tackled in a follow-up branch (suspects #4/#5/#6 from #50).

## Changes

### 1. `web/hooks/use-frame-ref-selector.ts` — shared 4Hz ticker (closes #50 suspect 1)

Each \`useFrameRefSelector\` instance previously created its own \`setInterval(250ms)\`. With N session canvases each instantiating M selectors (4 in \`SessionCanvasPanel\`: currentTime, isPlaying, speed, maxTimeReached), the app ran **N × M independent setIntervals** — at N=3 that's 12 timers firing 4Hz. Refactored to a module-level \`Set<() => void>\` of subscribers driven by a single \`setInterval\`. Public API unchanged.

Added regression test verifying that mounting 6 selectors registers exactly 1 \`setInterval\` (not 6).

### 2. \`web/components/agent-visualizer/session-canvas-panel.tsx\` + \`index.tsx\` — \`React.memo\` on SessionCanvasPanel (closes #50 suspect 3)

Every SSE event from any session calls \`setEventVersion(v+1)\` in \`useVSCodeBridge\` to coalesce React updates into one per rAF tick. That re-renders \`AgentVisualizerInner\`, which previously cascaded into all N \`SessionCanvasPanel\` children — an event for session A re-rendered B and C even though their data hadn't changed.

Wrap \`SessionCanvasPanel\` in \`React.memo\`. For memo to actually prevent re-renders, all callback props must be stable; the inline arrow \`onClose={() => hideCanvas(session.id)}\` was defeating it. Change the \`onClose\` API to \`(sessionId: string) => void\`, stabilize internally via \`useCallback\`, and pass the existing \`useCallback\`'d \`hideCanvas\` directly.

## Bench results (G-main, 1 rep × 2 throttles × 2 sim counts)

**sim=3 (workload-matched):**

| Metric | Pre-fix | This PR | Δ |
|---|---|---|---|
| **React commits @ 1×** | 3785 | **1929** | **−49%** ✓ |
| **React commits @ 4×** | 3116 | **1370** | **−56%** ✓ |
| FPS @ 1× | 111.7 | 85.4 | noisy* |
| FPS @ 4× | 11.5 | 11.5 | flat |
| p95 @ 4× | 118 ms | 116 ms | flat |
| Long-task blocking @ 4× | 80,871 ms | 81,795 ms | **~unchanged** (expected — render-path issue) |

**sim=1 (apples-to-apples — confirms no single-canvas regression):**

| Metric | Pre-fix | This PR |
|---|---|---|
| FPS @ 1× | 565 | 557 |
| Commits @ 1× | 1454 | 1097 (−25%) |
| Long tasks @ 4× | 346 ms | 360 ms |

*\\* FPS at 1× throttle is too noisy at 1-rep to draw conclusions — same stack swung 565 → 468 → 557 across runs while commits showed a clean −50%. Future runs should use 3+ reps for FPS attribution.*

## Tests

- All 5 \`use-frame-ref-selector.test.ts\` tests pass (4 existing + 1 new regression guard)
- TypeScript clean (\`pnpm exec tsc --noEmit\` from \`web/\`)

## Why this still ships even with flat long-task numbers

The React-commit reduction is real, stable across runs, and was the *predicted* outcome — not a side effect we have to argue about. Less main-thread work per event means lower overhead under load, even if it doesn't shift this particular bench metric. The long-task blocking is a separate problem (in the render pipeline) that the next PR will tackle.

Closes #50 (partial — suspects 1 and 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)