### PR TITLE
perf(canvas2d): add bloom toggle (closes #53)

### DIFF
--- a/web/components/agent-visualizer/canvas.tsx
+++ b/web/components/agent-visualizer/canvas.tsx
@@ -45,6 +45,9 @@ interface CanvasProps {
   onDiscoveryClick?: (discoveryId: string | null) => void
   selectedDiscoveryId?: string | null
   showCostOverlay?: boolean
+  /** When false, the Canvas2D bloom post-processing pass is skipped entirely.
+   *  Defaults to true to preserve existing visual appearance. */
+  bloomEnabled?: boolean
   /** Floor for the auto-fit scale. 0 (default) = no minimum. Manual wheel
    *  zoom is unaffected; this only constrains the auto-fit lerp. */
   minZoomLevel?: number
@@ -62,7 +65,7 @@ export function AgentCanvas({
   simulationRef,
   selectedAgentId, hoveredAgentId, showStats, showHexGrid, zoomToFitTrigger, pauseAutoFit,
   onAgentClick, onAgentHover, onAgentDrag, onContextMenu, onToolCallClick, selectedToolCallId, onDiscoveryClick, selectedDiscoveryId, showCostOverlay,
-  minZoomLevel, pauseWhenOffscreen = true,
+  bloomEnabled = true, minZoomLevel, pauseWhenOffscreen = true,
 }: CanvasProps) {
   const manager = useSimulationManager()
   const containerRef = useRef<HTMLDivElement>(null)
@@ -160,11 +163,15 @@ export function AgentCanvas({
   // ─── Setup ──────────────────────────────────────────────────────────────
 
   useEffect(() => {
-    bloomRef.current = new BloomRenderer(0.5)
+    if (bloomEnabled) {
+      bloomRef.current = new BloomRenderer(0.5)
+    } else {
+      bloomRef.current = null
+    }
     depthParticlesRef.current = createDepthParticles(dimensions.width, dimensions.height)
     return () => { bloomRef.current = null }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- particles created once, resized by draw loop
-  }, [])
+  }, [bloomEnabled])
 
   useEffect(() => {
     const container = containerRef.current

--- a/web/components/agent-visualizer/session-canvas-panel.tsx
+++ b/web/components/agent-visualizer/session-canvas-panel.tsx
@@ -303,6 +303,7 @@ function SessionCanvasPanelImpl({
               hoveredAgentId={hoveredAgentId}
               showStats={showStats}
               showHexGrid={showHexGrid}
+              bloomEnabled={effects.bloom}
               zoomToFitTrigger={combinedZoomToFitTrigger}
               pauseAutoFit={pauseAutoFit}
               onAgentClick={(id) => onAgentClick(id, sessionId)}

--- a/web/components/agent-visualizer/top-bar.tsx
+++ b/web/components/agent-visualizer/top-bar.tsx
@@ -356,10 +356,13 @@ function PerfButton({
     return () => window.removeEventListener('mousedown', handler)
   }, [open])
 
-  // Effect toggles only flow into the Pixi renderer; on Canvas2D they're
-  // visible in the UI but no-ops, so we hide them entirely off the Pixi path.
-  const showEffects = IS_PIXI_RENDERER
-  const offCount = showEffects ? Object.values(effects).filter(v => !v).length : 0
+  // Bloom toggle applies to both Canvas2D and Pixi renderers.
+  // Other effect toggles (particles, bubbles, backgroundParticles) only flow
+  // into the Pixi renderer, so they're hidden on the Canvas2D path.
+  const showAllEffects = IS_PIXI_RENDERER
+  const offCount = showAllEffects
+    ? Object.values(effects).filter(v => !v).length
+    : (effects.bloom ? 0 : 1)
   const capLabel = FRAME_CAP_OPTIONS.find(o => o.value === frameCap)?.label ?? 'Uncapped'
   const summary = offCount > 0
     ? `Perf · ${capLabel} · ${offCount} off`
@@ -402,32 +405,30 @@ function PerfButton({
         ))}
       </select>
 
-      {showEffects && (
-        <>
-          <div className="text-[10px] font-mono mb-1" style={{ color: COLORS.textMuted, letterSpacing: '0.08em' }}>
-            EFFECTS
-          </div>
-          {(Object.keys(EFFECT_LABELS) as Array<keyof EffectToggles>).map(key => (
-            <label
-              key={key}
-              className="flex items-center gap-2 py-1 px-1 rounded cursor-pointer"
-              style={{ color: effects[key] ? COLORS.textPrimary : COLORS.textMuted }}
-            >
-              <input
-                type="checkbox"
-                checked={effects[key]}
-                onChange={(e) => onEffectChange(key, e.target.checked)}
-                style={{ accentColor: COLORS.holoBase, cursor: 'pointer' }}
-              />
-              <span className="text-[10px] font-mono">{EFFECT_LABELS[key]}</span>
-            </label>
-          ))}
-        </>
-      )}
+      <div className="text-[10px] font-mono mb-1" style={{ color: COLORS.textMuted, letterSpacing: '0.08em' }}>
+        EFFECTS
+      </div>
+      {(Object.keys(EFFECT_LABELS) as Array<keyof EffectToggles>)
+        .filter(key => showAllEffects || key === 'bloom')
+        .map(key => (
+          <label
+            key={key}
+            className="flex items-center gap-2 py-1 px-1 rounded cursor-pointer"
+            style={{ color: effects[key] ? COLORS.textPrimary : COLORS.textMuted }}
+          >
+            <input
+              type="checkbox"
+              checked={effects[key]}
+              onChange={(e) => onEffectChange(key, e.target.checked)}
+              style={{ accentColor: COLORS.holoBase, cursor: 'pointer' }}
+            />
+            <span className="text-[10px] font-mono">{EFFECT_LABELS[key]}</span>
+          </label>
+        ))}
       <div className="text-[9px] font-mono mt-2 pt-2" style={{ color: COLORS.textMuted, borderTop: `1px solid ${COLORS.holoBorder06}` }}>
-        {showEffects
+        {showAllEffects
           ? 'Lower cap saves power; turning effects off cuts per-frame work.'
-          : 'Lower cap saves power. (Effect toggles only apply on the WebGL renderer.)'}
+          : 'Lower cap saves power; bloom is the heaviest Canvas2D effect.'}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Adds a user-visible bloom on/off toggle in the Perf popover that works on **both** Canvas2D and Pixi renderers. PR 56's CPU profile attributed **~49.5% of CPU at 4× throttle** to `BloomRenderer.apply()` on the Canvas2D path — this gives users a one-click escape hatch.

When OFF, `AgentCanvas` skips constructing `BloomRenderer` entirely (no canvas elements, no per-frame `apply()` call, zero overhead). Default ON to preserve existing visual behavior.

Reuses the existing `effects.bloom` persisted setting from `usePerfSettings` (previously wired only to Pixi). Other effect toggles (particles/bubbles/backgroundParticles) remain Pixi-only and stay hidden on Canvas2D.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 161/161 pass
- [ ] Manual: open the app on default Canvas2D path, open Perf popover, toggle bloom off → glow disappears, FPS improves; toggle on → glow returns.
- [ ] Manual: same on `?renderer=pixi` to confirm no Pixi regression.

Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)