### PR TITLE
perf(canvas2d): cache hex grid to offscreen canvas (closes part of #54)

### DIFF
--- a/web/components/agent-visualizer/background-layer.ts
+++ b/web/components/agent-visualizer/background-layer.ts
@@ -5,6 +5,111 @@ import { alphaHex } from '@/lib/utils'
 const NUM_PARTICLES = 80
 const HEX_GRID_SIZE = 60
 
+// ─── Hex grid off-screen cache ─────────────────────────────────────────────
+// Single-entry cache per AgentCanvas instance. Rebuilds when the cache key
+// changes; otherwise blits the pre-rendered off-screen canvas.
+//
+// The hex pulse animation depends on `time`; we quantize it to ~200ms steps
+// so the cache hits ~12/13 frames at 60fps while the animation still reads
+// as alive. This is the sole visual deviation from the uncached path — the
+// pulse updates at ~5Hz instead of every frame.
+
+/** Quantization step for the time component of the cache key (seconds). */
+const HEX_TIME_QUANT = 0.2
+
+export interface HexGridCache {
+  canvas: OffscreenCanvas | HTMLCanvasElement
+  key: string
+}
+
+export function createHexGridCache(): HexGridCache {
+  // Lazily sized on first use — start with a 1×1 placeholder.
+  const canvas =
+    typeof OffscreenCanvas !== 'undefined'
+      ? new OffscreenCanvas(1, 1)
+      : document.createElement('canvas')
+  return { canvas, key: '' }
+}
+
+/**
+ * Build a cache key from the values that affect the hex grid's pixel output.
+ * Camera translation is reduced mod the hex tile period so panning within a
+ * tile period reuses the same rendered grid (the grid tiles at `size * 1.5`
+ * horizontally and `hexHeight` vertically in world space, which maps to
+ * `period * scale` in screen space where tx/ty live).
+ */
+function hexCacheKey(
+  width: number,
+  height: number,
+  dpr: number,
+  scale: number,
+  tx: number,
+  ty: number,
+  time: number,
+): string {
+  const size = HEX_GRID_SIZE
+  const hexHeight = size * Math.sqrt(3)
+  // Screen-space repeat distance for the hex tiling.
+  const periodX = size * 1.5 * scale
+  const periodY = hexHeight * scale
+
+  // Reduce camera offset to the residual within one screen-space tile period.
+  // Round to 2 decimal places so floating-point jitter doesn't produce
+  // distinct keys for what amounts to the same pixel output.
+  const modX = Math.round(((tx % periodX) + periodX) % periodX * 100) / 100
+  const modY = Math.round(((ty % periodY) + periodY) % periodY * 100) / 100
+  const timeQ = Math.round(time / HEX_TIME_QUANT)
+  return `${width}|${height}|${dpr}|${scale.toFixed(4)}|${modX}|${modY}|${timeQ}`
+}
+
+/**
+ * Draw the hex grid, using the off-screen cache when possible.
+ * `dpr` is `window.devicePixelRatio` — the cache renders in device pixels.
+ */
+function drawHexGridCached(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  dpr: number,
+  transform: { x: number; y: number; scale: number },
+  time: number,
+  cache: HexGridCache,
+): void {
+  const key = hexCacheKey(width, height, dpr, transform.scale, transform.x, transform.y, time)
+
+  if (cache.key !== key) {
+    // Resize the off-screen canvas to match the on-screen canvas in device pixels.
+    const pw = Math.ceil(width * dpr)
+    const ph = Math.ceil(height * dpr)
+    if (cache.canvas.width !== pw || cache.canvas.height !== ph) {
+      cache.canvas.width = pw
+      cache.canvas.height = ph
+    }
+
+    const offCtx =
+      cache.canvas instanceof OffscreenCanvas
+        ? cache.canvas.getContext('2d') as OffscreenCanvasRenderingContext2D | null
+        : cache.canvas.getContext('2d')
+    if (!offCtx) return
+
+    // Clear and render at device-pixel scale.
+    offCtx.clearRect(0, 0, pw, ph)
+    offCtx.save()
+    offCtx.scale(dpr, dpr)
+
+    const timeQ = Math.round(time / HEX_TIME_QUANT) * HEX_TIME_QUANT
+    drawHexGrid(offCtx as unknown as CanvasRenderingContext2D, width, height, transform, timeQ)
+
+    offCtx.restore()
+    cache.key = key
+  }
+
+  // Blit the cached grid onto the main canvas.
+  // The main canvas context is already scaled by dpr, so we draw in CSS-pixel
+  // coordinates and let drawImage handle the device-pixel source.
+  ctx.drawImage(cache.canvas, 0, 0, width, height)
+}
+
 export function createDepthParticles(width: number, height: number): DepthParticle[] {
   const particles: DepthParticle[] = []
   for (let i = 0; i < NUM_PARTICLES; i++) {
@@ -45,6 +150,8 @@ export function drawBackground(
   showHexGrid: boolean,
   time: number,
   activeAgentPos?: { x: number; y: number; color: string },
+  dpr?: number,
+  hexCache?: HexGridCache,
 ): void {
   // Deep void
   ctx.fillStyle = COLORS.void
@@ -77,7 +184,11 @@ export function drawBackground(
 
   // Hex grid (optional)
   if (showHexGrid) {
-    drawHexGrid(ctx, width, height, transform, time)
+    if (hexCache && dpr) {
+      drawHexGridCached(ctx, width, height, dpr, transform, time, hexCache)
+    } else {
+      drawHexGrid(ctx, width, height, transform, time)
+    }
   }
 }
 
@@ -87,7 +198,7 @@ const HEX_OFFSETS = Array.from({ length: 6 }, (_, i) => {
   return { cos: Math.cos(angle), sin: Math.sin(angle) }
 })
 
-// Reused alpha → coordinate buckets for the hex grid. Drawn each frame; we
+// Reused alpha -> coordinate buckets for the hex grid. Drawn each frame; we
 // keep the Map and its value arrays alive across frames and just reset
 // array.length, instead of allocating a fresh Map + ~40 fresh arrays per
 // frame as the grid was previously doing.

--- a/web/components/agent-visualizer/canvas.tsx
+++ b/web/components/agent-visualizer/canvas.tsx
@@ -6,7 +6,7 @@ import type { SimulationState } from '@/hooks/simulation/types'
 import { getStateColor } from '@/lib/colors'
 import { ANIM_SPEED, PERF_OVERLAY, PERF_OVERLAY_ENABLED } from '@/lib/canvas-constants'
 import { BloomRenderer } from './bloom-renderer'
-import { createDepthParticles, updateDepthParticles, drawBackground } from './background-layer'
+import { createDepthParticles, updateDepthParticles, drawBackground, createHexGridCache, type HexGridCache } from './background-layer'
 import {
   type VisualEffect,
   drawTetherLine,
@@ -74,6 +74,7 @@ export function AgentCanvas({
   const depthParticlesRef = useRef<DepthParticle[]>([])
   const lastFrameTimeRef = useRef(0)
   const dprRef = useRef(1)
+  const hexGridCacheRef = useRef<HexGridCache>(createHexGridCache())
 
   // Effects system. `agentStatesA/B` and `toolStatesA/B` are alternating
   // snapshot pairs that detectStateChanges ping-pongs between — we hold them
@@ -290,7 +291,7 @@ export function AgentCanvas({
         }
       }
 
-      drawBackground(ctx, w, h, depthParticlesRef.current, transform, showHexGrid, timeRef.current, activeAgentPos)
+      drawBackground(ctx, w, h, depthParticlesRef.current, transform, showHexGrid, timeRef.current, activeAgentPos, dpr, hexGridCacheRef.current)
 
       ctx.save()
       ctx.translate(transform.x, transform.y)


### PR DESCRIPTION
## Summary

- Cache the Canvas2D hex-grid background to a per-instance off-screen canvas, blitting it per frame instead of re-running hundreds of `closePath`/`stroke` calls every frame.
- Cache key is `(width, height, dpr, scale, tx mod tilePeriod, ty mod tilePeriod, quantizedTime)` — rebuilds only when the visual output would actually change.
- The pulse animation is quantized to ~200ms steps (~5Hz) instead of every frame; this is the sole visual deviation from the uncached path.

**Expected savings:** ~1.5s / 1.7% of CPU at 4x throttle (PR #56's profile: `closePath` was hot-path #5, 98% from hex grid draw).

Closes part of #54.

## Test plan

- [ ] `pnpm exec tsc --noEmit` passes (zero errors)
- [ ] `pnpm test` passes (161 tests)
- [ ] `pnpm run build` succeeds
- [ ] Visual: hex grid renders identically with cache (open app, toggle hex grid on/off, pan/zoom)
- [ ] Visual: pulse animation still visible at ~5Hz cadence
- [ ] Multi-canvas: open multiple sessions, each canvas has independent hex grid cache
- [ ] Fallback: if `hexCache`/`dpr` not provided, falls back to uncached path

🤖 Generated with [Claude Code](https://claude.com/claude-code)