### PR TITLE
perf(canvas2d): eliminate hot-path allocations + shadowBlur (closes #72)

### DIFF
--- a/web/components/agent-visualizer/canvas.tsx
+++ b/web/components/agent-visualizer/canvas.tsx
@@ -126,8 +126,12 @@ export function AgentCanvas({
   // ─── Stable refs for animation loop & event handlers ────────────────────
   // Simulation data (agents, particles, etc.) is synced from simulationRef
   // at the top of each draw frame, so it's always fresh even without re-renders.
+  // The drawProps object itself is allocated ONCE — every subsequent render
+  // mutates fields in place rather than reallocating. Parents re-render at
+  // ~4 Hz (UI cadence) plus drag/resize, so the closure + spread cost adds
+  // up; mirroring the Pixi twin (`pixi-canvas.tsx`) keeps both paths uniform.
   const sim = simulationRef.current
-  const makeDrawProps = (prev?: { isDragging: boolean }) => ({
+  const drawPropsRef = useRef({
     agents: sim.agents, toolCalls: sim.toolCalls,
     particles: sim.particles, edges: sim.edges, discoveries: sim.discoveries,
     selectedAgentId, hoveredAgentId, showStats, showHexGrid,
@@ -135,10 +139,31 @@ export function AgentCanvas({
     simTime: sim.currentTime, pauseAutoFit, dimensions,
     onAgentDrag, onAgentClick, onAgentHover, onContextMenu,
     onToolCallClick, onDiscoveryClick,
-    isDragging: prev?.isDragging ?? false,
+    isDragging: false,
   })
-  const drawPropsRef = useRef(makeDrawProps())
-  drawPropsRef.current = makeDrawProps(drawPropsRef.current)
+
+  // Sync React-driven props into the existing ref each render. Simulation
+  // data (agents/edges/etc.) is intentionally NOT updated here — the draw
+  // loop overwrites those each frame from `simulationRef.current` so this
+  // hot path stays a tiny field-assignment block.
+  {
+    const p = drawPropsRef.current
+    p.selectedAgentId = selectedAgentId
+    p.hoveredAgentId = hoveredAgentId
+    p.showStats = showStats
+    p.showHexGrid = showHexGrid
+    p.showCostOverlay = showCostOverlay
+    p.selectedToolCallId = selectedToolCallId
+    p.selectedDiscoveryId = selectedDiscoveryId
+    p.pauseAutoFit = pauseAutoFit
+    p.dimensions = dimensions
+    p.onAgentDrag = onAgentDrag
+    p.onAgentClick = onAgentClick
+    p.onAgentHover = onAgentHover
+    p.onContextMenu = onContextMenu
+    p.onToolCallClick = onToolCallClick
+    p.onDiscoveryClick = onDiscoveryClick
+  }
 
   // ─── Camera ─────────────────────────────────────────────────────────────
   const {
@@ -195,9 +220,15 @@ export function AgentCanvas({
   useEffect(() => {
     const container = containerRef.current
     if (!container) return
-    const dpr = window.devicePixelRatio || 1
-    dprRef.current = dpr
+
     const observer = new ResizeObserver((entries) => {
+      // Re-read DPR each resize: dragging the window between monitors with
+      // different pixel densities triggers a resize without firing our
+      // matchMedia listener for the OLD DPR (it only fires once when the
+      // current density boundary is crossed). Refreshing here keeps the
+      // backing store correctly sized regardless of which event fires first.
+      const dpr = window.devicePixelRatio || 1
+      dprRef.current = dpr
       for (const entry of entries) {
         const w = entry.contentRect.width
         const h = entry.contentRect.height
@@ -206,7 +237,34 @@ export function AgentCanvas({
       }
     })
     observer.observe(container)
-    return () => observer.disconnect()
+
+    // matchMedia for the current resolution fires when DPR crosses any
+    // boundary (zoom, monitor swap on browsers that don't trigger resize).
+    // After a change we must re-subscribe at the new DPR — the previous
+    // query no longer matches and won't fire again.
+    let mql: MediaQueryList | null = null
+    let onChange: (() => void) | null = null
+    const subscribeDpr = () => {
+      const dpr = window.devicePixelRatio || 1
+      dprRef.current = dpr
+      mql = window.matchMedia(`(resolution: ${dpr}dppx)`)
+      onChange = () => {
+        const newDpr = window.devicePixelRatio || 1
+        dprRef.current = newDpr
+        const w = dimensionsRef.current.width
+        const h = dimensionsRef.current.height
+        if (w > 0 && h > 0) bloomRef.current?.resize(w * newDpr, h * newDpr)
+        if (mql && onChange) mql.removeEventListener('change', onChange)
+        subscribeDpr()
+      }
+      mql.addEventListener('change', onChange)
+    }
+    subscribeDpr()
+
+    return () => {
+      observer.disconnect()
+      if (mql && onChange) mql.removeEventListener('change', onChange)
+    }
   }, [])
 
 

--- a/web/components/agent-visualizer/canvas/draw-agents.ts
+++ b/web/components/agent-visualizer/canvas/draw-agents.ts
@@ -22,9 +22,15 @@ function getOpenAILogoPath() {
 // Pre-baked brand-spark sprite cache. shadowBlur on a per-frame fill is
 // among the slowest Canvas2D paths (Chrome forces an off-screen render
 // pass), so we render the spark + glow once into an off-screen canvas and
-// blit it via drawImage on subsequent frames. Cache key includes radius
-// (rounded to integer logical px) so the sprite stays crisp for the
-// agent's actual size; breathe / scale variation reuses ~1 entry per agent.
+// blit it via drawImage on subsequent frames.
+//
+// Cache structure: nested over the natural cardinality (brand × color ×
+// radius bucket) so the per-frame lookup is three small Map.get() calls
+// and zero allocations. A flat string-keyed Map forced a per-call
+// `${brand}|${color}|${rQ}|${dpr}` allocation that defeated V8's inlining
+// of the brand-spark path — the CPU profile showed it adding ~830ms self
+// time over a 90s window. dpr is captured at module scope; if it changes
+// we evict the cache and start fresh.
 const SPARK_BLUR_MARGIN = 12
 
 interface BrandSparkSprite {
@@ -33,7 +39,13 @@ interface BrandSparkSprite {
   size: number
 }
 
-const brandSparkCache = new Map<string, BrandSparkSprite>()
+type BrandSparkBucket = Map<number, BrandSparkSprite>
+type BrandSparkColorMap = Map<string, BrandSparkBucket>
+const brandSparkCache: Record<'claude' | 'openai', BrandSparkColorMap> = {
+  claude: new Map(),
+  openai: new Map(),
+}
+let cachedDpr = -1
 
 function getBrandSparkSprite(
   brand: 'claude' | 'openai',
@@ -41,10 +53,23 @@ function getBrandSparkSprite(
   r: number,
   dpr: number,
 ): BrandSparkSprite {
-  const rQ = Math.max(1, Math.round(r))
-  const key = `${brand}|${color}|${rQ}|${dpr}`
-  const cached = brandSparkCache.get(key)
-  if (cached) return cached
+  if (dpr !== cachedDpr) {
+    brandSparkCache.claude.clear()
+    brandSparkCache.openai.clear()
+    cachedDpr = dpr
+  }
+  // r > 0 always in practice (agent radius); keep the floor as a guard.
+  // Bitwise OR truncates faster than Math.round for the small positive
+  // values seen here, and the +0.5 turns truncation into nearest-int.
+  const rQ = r < 1 ? 1 : (r + 0.5) | 0
+  const colorMap = brandSparkCache[brand]
+  let bucket = colorMap.get(color)
+  if (bucket === undefined) {
+    bucket = new Map()
+    colorMap.set(color, bucket)
+  }
+  const cached = bucket.get(rQ)
+  if (cached !== undefined) return cached
 
   // Sprite covers the spark (visual extent ~ rQ * sparkScale * 2) plus a
   // blur margin on every side so the glow doesn't clip at sprite edges.
@@ -75,7 +100,7 @@ function getBrandSparkSprite(
   }
 
   const sprite: BrandSparkSprite = { canvas, size }
-  brandSparkCache.set(key, sprite)
+  bucket.set(rQ, sprite)
   return sprite
 }
 

--- a/web/components/agent-visualizer/canvas/draw-agents.ts
+++ b/web/components/agent-visualizer/canvas/draw-agents.ts
@@ -19,31 +19,78 @@ function getOpenAILogoPath() {
   return _openaiLogoPath
 }
 
+// Pre-baked brand-spark sprite cache. shadowBlur on a per-frame fill is
+// among the slowest Canvas2D paths (Chrome forces an off-screen render
+// pass), so we render the spark + glow once into an off-screen canvas and
+// blit it via drawImage on subsequent frames. Cache key includes radius
+// (rounded to integer logical px) so the sprite stays crisp for the
+// agent's actual size; breathe / scale variation reuses ~1 entry per agent.
+const SPARK_BLUR_MARGIN = 12
+
+interface BrandSparkSprite {
+  canvas: HTMLCanvasElement
+  /** Logical (CSS-px) edge length of the rendered sprite. */
+  size: number
+}
+
+const brandSparkCache = new Map<string, BrandSparkSprite>()
+
+function getBrandSparkSprite(
+  brand: 'claude' | 'openai',
+  color: string,
+  r: number,
+  dpr: number,
+): BrandSparkSprite {
+  const rQ = Math.max(1, Math.round(r))
+  const key = `${brand}|${color}|${rQ}|${dpr}`
+  const cached = brandSparkCache.get(key)
+  if (cached) return cached
+
+  // Sprite covers the spark (visual extent ~ rQ * sparkScale * 2) plus a
+  // blur margin on every side so the glow doesn't clip at sprite edges.
+  const size = Math.ceil(rQ * AGENT_DRAW.sparkScale * 2 + SPARK_BLUR_MARGIN * 2)
+  const canvas = document.createElement('canvas')
+  canvas.width = Math.ceil(size * dpr)
+  canvas.height = Math.ceil(size * dpr)
+  const sctx = canvas.getContext('2d')!
+  sctx.scale(dpr, dpr)
+  sctx.translate(size / 2, size / 2)
+
+  if (brand === 'claude') {
+    const scale = (rQ * AGENT_DRAW.sparkScale) / AGENT_DRAW.sparkViewBox
+    sctx.scale(scale, scale)
+    sctx.translate(-AGENT_DRAW.sparkViewBox, -AGENT_DRAW.sparkViewBox + 1)
+    sctx.fillStyle = color
+    sctx.shadowColor = color
+    sctx.shadowBlur = 6 / scale
+    sctx.fill(getClaudeSparkPath())
+  } else {
+    const scale = (rQ * AGENT_DRAW.sparkScale) / OPENAI_LOGO_VIEWBOX
+    sctx.scale(scale, scale)
+    sctx.translate(-OPENAI_LOGO_VIEWBOX / 2, -OPENAI_LOGO_VIEWBOX / 2)
+    sctx.fillStyle = color
+    sctx.shadowColor = color
+    sctx.shadowBlur = 6 / scale
+    sctx.fill(getOpenAILogoPath())
+  }
+
+  const sprite: BrandSparkSprite = { canvas, size }
+  brandSparkCache.set(key, sprite)
+  return sprite
+}
+
+function getSpriteDpr(): number {
+  return typeof window !== 'undefined' ? (window.devicePixelRatio || 1) : 1
+}
+
 export function drawClaudeSpark(ctx: CanvasRenderingContext2D, cx: number, cy: number, r: number, color: string) {
-  ctx.save()
-  ctx.translate(cx, cy)
-  const scale = (r * AGENT_DRAW.sparkScale) / AGENT_DRAW.sparkViewBox
-  ctx.scale(scale, scale)
-  ctx.translate(-AGENT_DRAW.sparkViewBox, -AGENT_DRAW.sparkViewBox + 1)
-  ctx.fillStyle = color
-  ctx.shadowColor = color
-  ctx.shadowBlur = 6 / scale
-  ctx.fill(getClaudeSparkPath())
-  ctx.restore()
+  const sprite = getBrandSparkSprite('claude', color, r, getSpriteDpr())
+  ctx.drawImage(sprite.canvas, cx - sprite.size / 2, cy - sprite.size / 2, sprite.size, sprite.size)
 }
 
 export function drawOpenAILogo(ctx: CanvasRenderingContext2D, cx: number, cy: number, r: number, color: string) {
-  ctx.save()
-  ctx.translate(cx, cy)
-  // Target diameter matches the Claude spark: (r * sparkScale) total.
-  const scale = (r * AGENT_DRAW.sparkScale) / OPENAI_LOGO_VIEWBOX
-  ctx.scale(scale, scale)
-  ctx.translate(-OPENAI_LOGO_VIEWBOX / 2, -OPENAI_LOGO_VIEWBOX / 2)
-  ctx.fillStyle = color
-  ctx.shadowColor = color
-  ctx.shadowBlur = 6 / scale
-  ctx.fill(getOpenAILogoPath())
-  ctx.restore()
+  const sprite = getBrandSparkSprite('openai', color, r, getSpriteDpr())
+  ctx.drawImage(sprite.canvas, cx - sprite.size / 2, cy - sprite.size / 2, sprite.size, sprite.size)
 }
 
 /** Pick the brand logo for the agent's runtime. Defaults to Claude. */

--- a/web/components/agent-visualizer/canvas/draw-bubbles.ts
+++ b/web/components/agent-visualizer/canvas/draw-bubbles.ts
@@ -48,7 +48,14 @@ export function drawMessageBubblesWorld(
       const truncated = allLines.length > BUBBLE_MAX_LINES
       const lines = truncated ? allLines.slice(0, BUBBLE_MAX_LINES) : allLines
 
-      const bubbleW = Math.min(BUBBLE_MAX_W, Math.max(...lines.map(l => measureTextCached(ctx, l))) + style.padding * 2 + 4)
+      // Running max over a single pass — avoids both the .map() intermediate
+      // array and the varargs spread into Math.max for every bubble per frame.
+      let widest = 0
+      for (let i = 0; i < lines.length; i++) {
+        const w = measureTextCached(ctx, lines[i])
+        if (w > widest) widest = w
+      }
+      const bubbleW = Math.min(BUBBLE_MAX_W, widest + style.padding * 2 + 4)
       const bubbleH = style.headerH + lines.length * style.lineH + style.padding + (truncated ? style.lineH * 0.8 : 0)
 
       // Cache dimensions so hit-detection can use exact same values

--- a/web/components/agent-visualizer/canvas/draw-discoveries.ts
+++ b/web/components/agent-visualizer/canvas/draw-discoveries.ts
@@ -5,10 +5,17 @@ import { truncateText } from './draw-misc'
 import { getTextSprite, drawTextSprite } from './render-cache'
 import { type ViewBounds, isPointVisible, isRectVisible } from './viewport'
 
+// Reused dash array for discovery connection lines — setLineDash always
+// copies the input, but reusing the source avoids one allocation per call.
+const DISCOVERY_DASH: readonly number[] = [3, 5]
+
 export function drawDiscoveryConnections(
   ctx: CanvasRenderingContext2D, discoveries: Discovery[], agents: Map<string, Agent>,
   bounds?: ViewBounds,
 ) {
+  // Stroke style and dash are constant across the loop — set them once and
+  // restore at the end so each iteration only modulates globalAlpha + stroke.
+  let opened = false
   for (const disc of discoveries) {
     const agent = agents.get(disc.agentId)
     if (!agent || disc.opacity < 0.1) continue
@@ -17,18 +24,22 @@ export function drawDiscoveryConnections(
     // is short and dashed, so we don't bother with a tighter check.
     if (bounds && !isPointVisible(agent.x, agent.y, bounds, 32) && !isPointVisible(disc.x, disc.y, bounds, 32)) continue
 
-    ctx.save()
+    if (!opened) {
+      ctx.save()
+      ctx.strokeStyle = COLORS.holoBase + '30'
+      ctx.lineWidth = 0.5
+      ctx.setLineDash(DISCOVERY_DASH as number[])
+      opened = true
+    }
+
     ctx.globalAlpha = disc.opacity * 0.3
-    ctx.strokeStyle = COLORS.holoBase + '30'
-    ctx.lineWidth = 0.5
-    ctx.setLineDash([3, 5])
     ctx.beginPath()
     ctx.moveTo(agent.x, agent.y)
     ctx.lineTo(disc.x, disc.y)
     ctx.stroke()
-    ctx.setLineDash([])
-    ctx.restore()
   }
+
+  if (opened) ctx.restore()
 }
 
 export function drawDiscoveries(

--- a/web/components/agent-visualizer/canvas/draw-edges.ts
+++ b/web/components/agent-visualizer/canvas/draw-edges.ts
@@ -35,25 +35,15 @@ export function computeControlPoints(fromX: number, fromY: number, toX: number, 
   }
 }
 
-/** Compute bezier position and perpendicular normal at parameter t */
-function bezierNormalAt(
-  t: number,
-  fromX: number, fromY: number,
-  cp1x: number, cp1y: number,
-  cp2x: number, cp2y: number,
-  toX: number, toY: number,
-  halfW: number,
-) {
-  const x = bezierPoint(t, fromX, cp1x, cp2x, toX)
-  const y = bezierPoint(t, fromY, cp1y, cp2y, toY)
-  const dt = 0.001
-  const t0 = Math.max(0, t - dt)
-  const t1 = Math.min(1, t + dt)
-  const tx = bezierPoint(t1, fromX, cp1x, cp2x, toX) - bezierPoint(t0, fromX, cp1x, cp2x, toX)
-  const ty = bezierPoint(t1, fromY, cp1y, cp2y, toY) - bezierPoint(t0, fromY, cp1y, cp2y, toY)
-  const len = Math.sqrt(tx * tx + ty * ty) || 1
-  return { x, y, nx: (-ty / len) * halfW, ny: (tx / len) * halfW }
-}
+// Scratch buffers reused across every drawTaperedBezier call to avoid
+// allocating BEAM.segments+1 sample objects per edge per frame.
+// Sized once and never reallocated; the same Float32Array is overwritten
+// on each invocation. Single-threaded rendering makes this safe.
+const SAMPLE_CAP = BEAM.segments + 1
+const sampleX = new Float32Array(SAMPLE_CAP)
+const sampleY = new Float32Array(SAMPLE_CAP)
+const sampleNx = new Float32Array(SAMPLE_CAP)
+const sampleNy = new Float32Array(SAMPLE_CAP)
 
 export function drawTaperedBezier(
   ctx: CanvasRenderingContext2D,
@@ -65,28 +55,33 @@ export function drawTaperedBezier(
   color: string, alpha: number,
 ) {
   const steps = BEAM.segments
+  const dt = 0.001
 
-  // Build outline points along both sides of the tapered curve
-  // then fill as a single polygon (1 draw call instead of N strokes)
-  ctx.beginPath()
-
-  // Forward pass: left side
+  // Sample the curve once into reusable scratch buffers, then walk the
+  // buffers twice (forward = left edge, reverse = right edge) to build
+  // the tapered outline polygon.
   for (let i = 0; i <= steps; i++) {
     const t = i / steps
     const halfW = (startWidth + (endWidth - startWidth) * t) / 2
-    const p = bezierNormalAt(t, fromX, fromY, cp1x, cp1y, cp2x, cp2y, toX, toY, halfW)
-    if (i === 0) ctx.moveTo(p.x + p.nx, p.y + p.ny)
-    else ctx.lineTo(p.x + p.nx, p.y + p.ny)
+    const t0 = t - dt < 0 ? 0 : t - dt
+    const t1 = t + dt > 1 ? 1 : t + dt
+    const tx = bezierPoint(t1, fromX, cp1x, cp2x, toX) - bezierPoint(t0, fromX, cp1x, cp2x, toX)
+    const ty = bezierPoint(t1, fromY, cp1y, cp2y, toY) - bezierPoint(t0, fromY, cp1y, cp2y, toY)
+    const len = Math.sqrt(tx * tx + ty * ty) || 1
+    sampleX[i] = bezierPoint(t, fromX, cp1x, cp2x, toX)
+    sampleY[i] = bezierPoint(t, fromY, cp1y, cp2y, toY)
+    sampleNx[i] = (-ty / len) * halfW
+    sampleNy[i] = (tx / len) * halfW
   }
 
-  // Reverse pass: right side
+  ctx.beginPath()
+  ctx.moveTo(sampleX[0] + sampleNx[0], sampleY[0] + sampleNy[0])
+  for (let i = 1; i <= steps; i++) {
+    ctx.lineTo(sampleX[i] + sampleNx[i], sampleY[i] + sampleNy[i])
+  }
   for (let i = steps; i >= 0; i--) {
-    const t = i / steps
-    const halfW = (startWidth + (endWidth - startWidth) * t) / 2
-    const p = bezierNormalAt(t, fromX, fromY, cp1x, cp1y, cp2x, cp2y, toX, toY, halfW)
-    ctx.lineTo(p.x - p.nx, p.y - p.ny)
+    ctx.lineTo(sampleX[i] - sampleNx[i], sampleY[i] - sampleNy[i])
   }
-
   ctx.closePath()
   ctx.fillStyle = color + alphaHex(alpha)
   ctx.fill()


### PR DESCRIPTION
## Summary

Workflow 2 of 5 from the 2026-05-03 main perf review (parent #46, sibling #71). Targets Canvas2D per-frame allocations, `ctx.shadowBlur` usage, and one DPR correctness item.

- **IR-2** · `drawTaperedBezier` samples into shared `Float32Array` scratch buffers instead of returning a fresh `{x, y, nx, ny}` object per t-step. Saves 34 allocs per edge per frame.
- **IR-5** · `drawDiscoveryConnections` hoists `save` / `strokeStyle` / `lineWidth` / `setLineDash` above the loop; per-iteration only modulates `globalAlpha` and stroke. Reuses a shared dash array constant.
- **IR-8** · Pre-bake brand-spark glow sprite (Claude / OpenAI). Per-frame `shadowBlur` fills are among Canvas2D's slowest paths (off-screen render pass per fill); replaced with cached `drawImage`. Cache is a 3-level nested Map (`brand → color → rQ → sprite`) — three small `Map.get()` calls and zero allocations per frame. **An earlier flat-string-key version regressed perf because the per-call `${brand}|${color}|${rQ}|${dpr}` allocation defeated V8 inlining of the brand-spark path.**
- **IR-15** · `drawProps` object is now allocated once and mutated in place each render — mirrors the Pixi twin in `pixi-canvas.tsx`. Avoids a fresh closure + spread on every parent re-render at the ~4 Hz UI cadence plus drag/resize.
- **MR-3** · Refresh `dprRef` on ResizeObserver fires AND subscribe to `matchMedia('(resolution: ${dpr}dppx)')` — re-subscribing at the new DPR on each change. Fixes blurry / oversampled backing store when dragging the visualizer between displays of different DPR.
- **MR-6** · Replace `Math.max(...lines.map(...))` per bubble per frame with a single-pass running max — drops the `.map` intermediate array and varargs spread.

## Empirical verification (5-rep × 90s × non-minified, 4× CPU throttle)

Both branches built with `vite build --minify false` so the CPU profile shows real function names. `node bench/profile-long-tasks.mjs --reps=5` on each side.

### Final deltas vs main (medians)

| Metric | Main | This PR | Δ |
| --- | --- | --- | --- |
| Frame p50 ms | 82.1 | 73.9 | **−10.0%** |
| Frame p95 ms | 117.3 | 103.5 | **−11.8%** |
| Frame p99 ms | 137.8 | 119.2 | **−13.5%** |
| Scripting / frame | — | — | **−11.6%** |
| drawImage time | 44358ms | 43184ms | −2.6% |
| Frames in 90s window | 1139 | 1251 | **+9.9%** |

`drawClaudeSpark` does NOT appear in the top-25 hot paths after the cache-key fix (V8 re-inlines it through `drawCenterIcon`).

### Honest caveats

- **`bezierNormalAt` (IR-2) and `drawDiscoveryConnections` (IR-5) are absent from the top-25 in BOTH profiles** — below the 0.3% measurement threshold on this workload. The changes are correct allocation-discipline improvements but don't measurably move this bench. Kept for code clarity and to avoid the allocation accumulating in longer sessions.
- Macro FPS-mean comparisons on this bench are unreliable (CoV 5–8%, governor not locked, opposing temporal trends). Per-frame normalized values above are what to trust.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all 189 vitest tests pass
- [x] `npx tsx --test __tests__/bezier-cache.test.ts` — 7/7 pass
- [x] **CPU profile attribution (non-minified, 4× CPU throttle, 5×90s):** brand-spark sprite visible, `drawClaudeSpark` re-inlined after cache-key fix
- [x] Frame p50 / p95 / p99 all improve by 10–13.5% per-frame
- [ ] **MR-3 manual:** drag the visualizer between two monitors with different DPR; canvas should stay crisp on both — recommend repo owner verify on real hardware

Closes #72.