### PR TITLE
perf(pixi): WG-1 rendering hot path — atlas churn, GPU lifecycle, beam contract (#71)

### DIFF
--- a/web/components/agent-visualizer/pixi/agents-layer.test.ts
+++ b/web/components/agent-visualizer/pixi/agents-layer.test.ts
@@ -84,15 +84,23 @@ vi.mock('./pixi-app', () => ({
 }))
 
 // ─── Mock GlyphAtlas ─────────────────────────────────────────────────────
+//
+// vi.hoisted lets `getGlyphSpy` be referenced inside the vi.mock factory
+// (which is hoisted above all imports). The spy lets CR-2 tests count
+// exactly how many glyph requests the layer made for stats overlay text.
+
+const { getGlyphSpy } = vi.hoisted(() => ({
+  getGlyphSpy: vi.fn((text: string, _color: string, fontSize?: number) => ({
+    texture: { destroy: () => {}, source: {} },
+    width: text.length * 6,
+    height: (fontSize ?? 10) * 1.4,
+  })),
+}))
 
 vi.mock('./glyph-atlas', () => ({
   GlyphAtlas: class {
     getGlyph(text: string, color: string, fontSize?: number) {
-      return {
-        texture: { destroy: () => {}, source: {} },
-        width: text.length * 6,
-        height: (fontSize ?? 10) * 1.4,
-      }
+      return getGlyphSpy(text, color, fontSize)
     }
     dispose() { /* no-op */ }
   },
@@ -300,5 +308,84 @@ describe('AgentsLayer', () => {
 
     expect(layer.getEntry('a1')!.pulseRing.visible).toBe(true)
     expect(layer.getEntry('a2')!.pulseRing.visible).toBe(false)
+  })
+
+  // ─── CR-3: leak prevention focused on sub-agents ─────────────────────────
+  // The earlier "destroys entries" test covers a single-frame transition.
+  // This pins down behaviour over a multi-frame window using sub-agents
+  // (isMain=false, the population the simulation actually evicts) so a
+  // future "grace period" or "isMain only" condition added to the sweep
+  // would surface here.
+
+  it('CR-3: sub-agents stable for 5 frames then absent → entries map empties', () => {
+    const layer = new AgentsLayer()
+
+    const subAgents = new Map<string, Agent>([
+      ['s1', makeAgent('s1', { isMain: false })],
+      ['s2', makeAgent('s2', { isMain: false })],
+      ['s3', makeAgent('s3', { isMain: false })],
+    ])
+
+    for (let frame = 0; frame < 5; frame++) {
+      layer.update(subAgents, null, null, false, frame * 0.016)
+    }
+    expect(layer.entryCount).toBe(3)
+
+    // Frame 6: zero sub-agents — full sweep.
+    layer.update(new Map(), null, null, false, 5 * 0.016)
+    expect(layer.entryCount).toBe(0)
+    expect(layer.getEntry('s1')).toBeUndefined()
+    expect(layer.getEntry('s2')).toBeUndefined()
+    expect(layer.getEntry('s3')).toBeUndefined()
+  })
+
+  // ─── CR-2: glyph-request cap on stats overlay ────────────────────────────
+  // Pre-fix the stats overlay was a single sprite carrying
+  // `${toolCalls} tools · ${timeAlive.toFixed(1)}s`. Because timeAlive
+  // ticks every frame (~60Hz), a unique glyph was uploaded to the atlas
+  // every frame — pumping the LRU and pinning the perf regression.
+  //
+  // Post-fix the overlay is split into a stable label sprite and a value
+  // sprite quantized to integer seconds. Over 100 frames covering 10
+  // simulated seconds, the label requires 1 glyph (toolCalls constant)
+  // and the value requires at most 11 (one per integer-second crossing,
+  // plus the initial render).
+  //
+  // A regression that drops the integer quantization or recombines the
+  // sprite would push the value sprite back into the 100s — this test
+  // catches that.
+
+  it('CR-2: stats overlay value sprite re-renders ≤11 times across 100 frames at 10Hz', () => {
+    const layer = new AgentsLayer()
+    const agent = makeAgent('a1', { toolCalls: 3, timeAlive: 0 })
+    const agents = new Map<string, Agent>([['a1', agent]])
+
+    // Warm-up: spawn the entry and capture initial glyph requests so
+    // subsequent calls are attributable to the stats overlay updates only.
+    layer.update(agents, null, null, true, 0)
+    getGlyphSpy.mockClear()
+
+    // 100 frames, +0.1s per frame → timeAlive sweeps 0.1 .. 10.0
+    // Floor(timeAlive) crosses 10 distinct integer seconds (0..9).
+    for (let frame = 1; frame <= 100; frame++) {
+      agent.timeAlive = frame * 0.1
+      layer.update(agents, null, null, true, frame * 0.016)
+    }
+
+    // Filter the spy calls by sprite kind. The value text matches /^\d+s$/
+    // (e.g. "0s", "1s"); the label text is "3 tools · " (toolCalls=3).
+    const allCalls = getGlyphSpy.mock.calls
+    const valueCalls = allCalls.filter(([text]) => /^\d+s$/.test(text))
+    const labelCalls = allCalls.filter(([text]) => text === '3 tools · ')
+
+    // Value sprite: one per integer-second crossing (0..9) — ≤ 11 leaves
+    // a bucket for the initial render.
+    expect(valueCalls.length).toBeGreaterThan(0) // at least re-rendered
+    expect(valueCalls.length).toBeLessThanOrEqual(11)
+
+    // Label sprite: toolCalls is constant, so label stays at 0 calls
+    // after warm-up (or 1 if the first warm-up call was missed). Allow
+    // for either; the contract is "no per-frame churn".
+    expect(labelCalls.length).toBeLessThanOrEqual(1)
   })
 })

--- a/web/components/agent-visualizer/pixi/agents-layer.test.ts
+++ b/web/components/agent-visualizer/pixi/agents-layer.test.ts
@@ -250,7 +250,11 @@ describe('AgentsLayer', () => {
     expect(layer.entryCount).toBe(0)
   })
 
-  it('agents that disappear between frames are hidden', () => {
+  it('destroys entries for agents that disappear between frames', () => {
+    // Stale-id sweep (CR-3): when an agent id no longer appears in the
+    // current frame's input, its entry is destroyed and removed from the
+    // map. Previously entries were merely hidden, so the entry map grew
+    // monotonically over long sessions.
     const layer = new AgentsLayer()
 
     // Frame 1: two agents
@@ -261,14 +265,16 @@ describe('AgentsLayer', () => {
     layer.update(agents1, null, null, false, 0)
     expect(layer.getEntry('a1')!.container.visible).toBe(true)
     expect(layer.getEntry('a2')!.container.visible).toBe(true)
+    expect(layer.entryCount).toBe(2)
 
-    // Frame 2: only a1 remains
+    // Frame 2: only a1 remains — a2 entry is destroyed and removed
     const agents2 = new Map<string, Agent>([
       ['a1', makeAgent('a1')],
     ])
     layer.update(agents2, null, null, false, 1)
     expect(layer.getEntry('a1')!.container.visible).toBe(true)
-    expect(layer.getEntry('a2')!.container.visible).toBe(false)
+    expect(layer.getEntry('a2')).toBeUndefined()
+    expect(layer.entryCount).toBe(1)
   })
 
   it('created entries have eventMode set to static', () => {

--- a/web/components/agent-visualizer/pixi/agents-layer.ts
+++ b/web/components/agent-visualizer/pixi/agents-layer.ts
@@ -37,16 +37,31 @@ interface AgentEntry {
   hoverHalo: Graphics
   /** Name label sprite (from glyph atlas). */
   labelSprite: Sprite | null
-  /** Stats overlay sprite (from glyph atlas). */
-  statsSprite: Sprite | null
+  /** Stable label portion of the stats overlay (e.g. "3 tools · ").
+   *  Re-rendered only when `agent.toolCalls` changes — once per tool call,
+   *  not once per frame. */
+  statsLabelSprite: Sprite | null
+  /** Volatile value portion of the stats overlay (e.g. "12s").
+   *  Re-rendered only when `Math.floor(agent.timeAlive)` changes — at most
+   *  1Hz, instead of the previous toFixed(1) churn at frame rate. */
+  statsValueSprite: Sprite | null
+  /** Cached width of the label sprite's glyph (used to position the value
+   *  sprite to its right). Updated whenever the label re-renders. */
+  statsLabelW: number
+  /** Cached width of the value sprite's glyph. */
+  statsValueW: number
   /** Active pulse ring (for thinking state animation). */
   pulseRing: Graphics
   /** Last-rendered label text (to detect changes). */
   lastLabelText: string
   /** Last-rendered label color. */
   lastLabelColor: string
-  /** Last-rendered stats text. */
-  lastStatsText: string
+  /** Last-rendered tool-call count for the stats label sprite. -1 sentinel
+   *  forces re-render on first sight (since 0 is a valid agent.toolCalls). */
+  lastStatsLabelCount: number
+  /** Last-rendered integer second for the stats value sprite. -1 sentinel
+   *  forces re-render on first sight. */
+  lastStatsValueSec: number
   /** Agent id. */
   agentId: string
 }
@@ -174,34 +189,76 @@ export class AgentsLayer {
       }
 
       // ── Stats overlay ──────────────────────────────────────────────
+      // CR-2: split the previous "${toolCalls} tools · ${timeAlive.toFixed(1)}s"
+      // glyph into a stable label part and a 1Hz-quantized value part. The
+      // old string changed every frame (toFixed(1) ticks ~60Hz), pumping a
+      // unique entry into the glyph atlas each frame and churning the LRU.
       if (showStats && agent.state !== 'complete') {
-        const statsText = `${agent.toolCalls} tools · ${agent.timeAlive.toFixed(1)}s`
-        if (statsText !== entry.lastStatsText) {
-          if (entry.statsSprite) {
-            entry.container.removeChild(entry.statsSprite)
-            entry.statsSprite.destroy()
+        // Label re-renders only on tool-call count change.
+        if (agent.toolCalls !== entry.lastStatsLabelCount) {
+          if (entry.statsLabelSprite) {
+            entry.container.removeChild(entry.statsLabelSprite)
+            entry.statsLabelSprite.destroy()
           }
-          const glyph = this.glyphAtlas.getGlyph(statsText, '#66ccff90', STATS_OVERLAY.fontSize)
-          const sprite = new Sprite(glyph.texture)
-          sprite.anchor.set(0.5, 1)
-          sprite.label = 'stats'
+          const labelText = `${agent.toolCalls} tools · `
+          const labelGlyph = this.glyphAtlas.getGlyph(labelText, '#66ccff90', STATS_OVERLAY.fontSize)
+          const sprite = new Sprite(labelGlyph.texture)
+          sprite.anchor.set(0, 1)
+          sprite.label = 'stats-label'
           entry.container.addChild(sprite)
-          entry.statsSprite = sprite
-          entry.lastStatsText = statsText
+          entry.statsLabelSprite = sprite
+          entry.statsLabelW = labelGlyph.width
+          entry.lastStatsLabelCount = agent.toolCalls
         }
-        if (entry.statsSprite) {
-          entry.statsSprite.y = -(radius + STATS_OVERLAY.yOffset)
-          entry.statsSprite.visible = true
+
+        // Value re-renders only when the integer second changes.
+        const seconds = Math.floor(agent.timeAlive)
+        if (seconds !== entry.lastStatsValueSec) {
+          if (entry.statsValueSprite) {
+            entry.container.removeChild(entry.statsValueSprite)
+            entry.statsValueSprite.destroy()
+          }
+          const valueText = `${seconds}s`
+          const valueGlyph = this.glyphAtlas.getGlyph(valueText, '#66ccff90', STATS_OVERLAY.fontSize)
+          const sprite = new Sprite(valueGlyph.texture)
+          sprite.anchor.set(0, 1)
+          sprite.label = 'stats-value'
+          entry.container.addChild(sprite)
+          entry.statsValueSprite = sprite
+          entry.statsValueW = valueGlyph.width
+          entry.lastStatsValueSec = seconds
         }
-      } else if (entry.statsSprite) {
-        entry.statsSprite.visible = false
+
+        // Position both sprites so the combined glyph row is centered
+        // horizontally above the agent. Recomputed every frame because
+        // either width may have changed; both are O(1) numeric writes.
+        const totalW = entry.statsLabelW + entry.statsValueW
+        const baseY = -(radius + STATS_OVERLAY.yOffset)
+        if (entry.statsLabelSprite) {
+          entry.statsLabelSprite.x = -totalW / 2
+          entry.statsLabelSprite.y = baseY
+          entry.statsLabelSprite.visible = true
+        }
+        if (entry.statsValueSprite) {
+          entry.statsValueSprite.x = -totalW / 2 + entry.statsLabelW
+          entry.statsValueSprite.y = baseY
+          entry.statsValueSprite.visible = true
+        }
+      } else {
+        if (entry.statsLabelSprite) entry.statsLabelSprite.visible = false
+        if (entry.statsValueSprite) entry.statsValueSprite.visible = false
       }
     }
 
-    // Hide entries for agents that no longer exist
+    // Drop entries for agents that no longer exist this frame. The
+    // simulation already enforces fade timing (animate.ts evicts faded
+    // sub-agents only after opacity reaches 0), so layers can mirror its
+    // decisions without a grace period. Previously entries were merely
+    // hidden, accumulating monotonically over long sessions.
     for (const [id, entry] of this.entries) {
       if (!aliveIds.has(id)) {
-        entry.container.visible = false
+        entry.container.destroy({ children: true })
+        this.entries.delete(id)
       }
     }
   }
@@ -265,11 +322,15 @@ export class AgentsLayer {
       selectionRing,
       hoverHalo,
       labelSprite: null,
-      statsSprite: null,
+      statsLabelSprite: null,
+      statsValueSprite: null,
+      statsLabelW: 0,
+      statsValueW: 0,
       pulseRing,
       lastLabelText: '',
       lastLabelColor: '',
-      lastStatsText: '',
+      lastStatsLabelCount: -1,
+      lastStatsValueSec: -1,
       agentId,
     }
   }

--- a/web/components/agent-visualizer/pixi/background-layer.test.ts
+++ b/web/components/agent-visualizer/pixi/background-layer.test.ts
@@ -29,7 +29,14 @@ vi.mock('pixi.js', () => {
     label = ''
     x = 0
     y = 0
-    tint = 0xffffff
+    private _tint = 0xffffff
+    // Per-instance tint-write counter added for MR-2 (glow tint cache)
+    // verification. The setter increments the counter on every assignment,
+    // even when the value is unchanged. Existing tests read `tint` as a
+    // plain field; the getter/setter pair preserves that interface.
+    _tintWrites = 0
+    get tint() { return this._tint }
+    set tint(v: number) { this._tint = v; this._tintWrites++ }
     alpha = 1
     visible = true
     blendMode = 'normal'
@@ -137,5 +144,85 @@ describe('BackgroundLayer', () => {
 
     layer.dispose()
     expect(layer.particleCount).toBe(0)
+  })
+
+  // ─── IR-7: zero-allocation hex grid ──────────────────────────────────────
+  // Pre-fix the hex-grid path called `new Map()` every frame to bucket
+  // cells by alpha — a steady allocation rate visible in heap profiles.
+  // Post-fix uses a module-level HEX_BUCKETS Map whose value arrays are
+  // truncated (`arr.length = 0`) instead of replaced.
+  //
+  // The test wraps the global Map constructor, runs a hex-draw frame, and
+  // asserts no Map is constructed during that frame. A regression that
+  // re-introduces `new Map()` in the hot path would fail immediately.
+
+  it('IR-7: hex-grid frames do NOT construct any new Map instances', () => {
+    const layer = new BackgroundLayer()
+    const transform = { x: 0, y: 0, scale: 1 }
+
+    // Warm-up: first call initialises particles + populates HEX_BUCKETS.
+    // The hex grid is drawn on even frames (frameCount % 2 === 0), and the
+    // very first call is frameCount=1 → particles only. The second call
+    // hits the hex draw and primes module-level buckets.
+    layer.update(800, 600, transform, 0.016, 0, true)
+    layer.update(800, 600, transform, 0.016, 0.016, true)
+
+    // Now wrap globalThis.Map and run another hex-draw frame.
+    const RealMap = globalThis.Map
+    let mapConstructions = 0
+    class CountingMap<K, V> extends RealMap<K, V> {
+      constructor(...args: ConstructorParameters<typeof Map>) {
+        super(...(args as [Iterable<readonly [K, V]>?]))
+        mapConstructions++
+      }
+    }
+    globalThis.Map = CountingMap as unknown as typeof Map
+
+    try {
+      // Run two more frames. One will be the hex-draw frame; the other won't.
+      // Either way, the post-fix code must not allocate any Maps in this window.
+      layer.update(800, 600, transform, 0.016, 0.032, true)
+      layer.update(800, 600, transform, 0.016, 0.048, true)
+    } finally {
+      globalThis.Map = RealMap
+    }
+
+    expect(mapConstructions).toBe(0)
+  })
+
+  // ─── MR-2: glow tint cache ───────────────────────────────────────────────
+  // Pre-fix the active-agent glow re-parsed the color string and re-wrote
+  // the sprite's tint every frame. Post-fix the work is gated on a string
+  // comparison against `lastGlowColor` — no parse, no tint write when the
+  // active agent's color is unchanged.
+
+  it('MR-2: active-agent glow tint is written once per color change, not per frame', () => {
+    const layer = new BackgroundLayer()
+    const transform = { x: 0, y: 0, scale: 1 }
+    const agentPos = { x: 100, y: 200, color: '#66ccff' }
+
+    // Frame 1: initial paint — tint is written (lastGlowColor was '').
+    layer.update(800, 600, transform, 0.016, 0, false, agentPos)
+    const glowSprite = (layer as unknown as {
+      glowSprite: { _tintWrites: number; tint: number }
+    }).glowSprite
+    expect(glowSprite._tintWrites).toBe(1)
+
+    // 30 frames with the SAME color → no further tint writes.
+    for (let frame = 1; frame <= 30; frame++) {
+      layer.update(800, 600, transform, 0.016, frame * 0.016, false, agentPos)
+    }
+    expect(glowSprite._tintWrites).toBe(1)
+
+    // Change the color → exactly one more tint write.
+    const agentPos2 = { x: 100, y: 200, color: '#ffbb44' }
+    layer.update(800, 600, transform, 0.016, 31 * 0.016, false, agentPos2)
+    expect(glowSprite._tintWrites).toBe(2)
+
+    // Another 10 frames at the new color → still 2 writes total.
+    for (let frame = 32; frame <= 41; frame++) {
+      layer.update(800, 600, transform, 0.016, frame * 0.016, false, agentPos2)
+    }
+    expect(glowSprite._tintWrites).toBe(2)
   })
 })

--- a/web/components/agent-visualizer/pixi/background-layer.ts
+++ b/web/components/agent-visualizer/pixi/background-layer.ts
@@ -43,6 +43,14 @@ const HOLO_TINT = parseColor(COLORS.holoBase)
 const HEX_GRID_TINT = parseColor(COLORS.hexGrid)
 
 /**
+ * Module-scope reusable bucket map for IR-7 alpha-bucketed hex-grid drawing.
+ * Keyed by quantized alpha; values are flat [cx, cy, …] coordinate arrays.
+ * Reused across frames: we clear each value's length to 0 instead of
+ * allocating a fresh Map. Mirrors the canvas2d HEX_BUCKETS singleton.
+ */
+const HEX_BUCKETS = new Map<number, number[]>()
+
+/**
  * Manages the background rendering layer. Contains depth particles,
  * an optional hex grid, and an active-agent highlight glow.
  */
@@ -60,6 +68,10 @@ export class BackgroundLayer {
 
   /** Active-agent glow sprite. */
   private glowSprite: Sprite
+
+  /** Last `activeAgentPos.color` string the glow tint was set from. The hex
+   *  parse + tint write are skipped when the color is unchanged. (MR-2) */
+  private lastGlowColor: string = ''
 
   /** Frame counter for lower-cadence ticks. */
   private frameCount = 0
@@ -137,7 +149,13 @@ export class BackgroundLayer {
       this.glowSprite.visible = true
       this.glowSprite.x = activeAgentPos.x
       this.glowSprite.y = activeAgentPos.y
-      this.glowSprite.tint = parseColor(activeAgentPos.color)
+      // MR-2: only re-parse + reassign tint when the color string actually
+      // changes. Active-agent identity changes far less often than the
+      // frame rate, so this is mostly a string compare per frame.
+      if (activeAgentPos.color !== this.lastGlowColor) {
+        this.glowSprite.tint = parseColor(activeAgentPos.color)
+        this.lastGlowColor = activeAgentPos.color
+      }
     } else {
       this.glowSprite.visible = false
     }
@@ -236,9 +254,12 @@ export class BackgroundLayer {
     const endX = startX + width / transform.scale + size * 6
     const endY = startY + height / transform.scale + hexHeight * 4
 
-    // Alpha-bucketed drawing (same strategy as Canvas2D)
+    // Alpha-bucketed drawing (same strategy as Canvas2D).
+    // IR-7: reuse the module-scope HEX_BUCKETS Map instead of allocating
+    // a fresh one each frame. Hex grids touch hundreds of cells per frame
+    // and the previous `new Map()` produced a steady allocation rate.
     const timeSin = time * 0.5
-    const buckets = new Map<number, number[]>()
+    for (const arr of HEX_BUCKETS.values()) arr.length = 0
 
     for (let x = startX; x < endX; x += size * 1.5) {
       for (let y = startY; y < endY; y += hexHeight) {
@@ -249,13 +270,13 @@ export class BackgroundLayer {
         const pulse = Math.sin(timeSin + dist * 0.005) * 0.3 + 0.7
         const alpha = Math.round(0.15 * pulse * 40) / 40
 
-        let bucket = buckets.get(alpha)
-        if (!bucket) { bucket = []; buckets.set(alpha, bucket) }
+        let bucket = HEX_BUCKETS.get(alpha)
+        if (!bucket) { bucket = []; HEX_BUCKETS.set(alpha, bucket) }
         bucket.push(cx, cy)
       }
     }
 
-    for (const [alpha, coords] of buckets) {
+    for (const [alpha, coords] of HEX_BUCKETS) {
       if (coords.length === 0) continue
 
       for (let i = 0; i < coords.length; i += 2) {

--- a/web/components/agent-visualizer/pixi/bezier-cache.test.ts
+++ b/web/components/agent-visualizer/pixi/bezier-cache.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Regression tests for the Pixi BezierCache module.
+ *
+ * Pins down two contracts established by the WG-1 perf pass:
+ *   - IR-1: a single module-level `sharedBezierCache` instance is reused
+ *     across EdgesLayer, ParticlesLayer, and instantiation cycles. Any
+ *     attempt to "clean up on dispose" by clearing the cache, or to make
+ *     each layer hold its own cache, would silently regress particle
+ *     rendering performance and/or topology consistency between layers.
+ *   - IR-2: `samplePolyline(polyline, t, scratch)` mutates and returns the
+ *     caller-provided scratch object. The hot path (particles-layer) calls
+ *     this thousands of times per frame; allocating a fresh object per
+ *     call would re-introduce the GC churn the out-param was designed to
+ *     eliminate.
+ *
+ * This file uses the REAL bezier-cache module (no vi.mock) so the assertions
+ * exercise the actual implementation. pixi.js is mocked minimally for tests
+ * that need to instantiate EdgesLayer/ParticlesLayer.
+ *
+ * Run with: cd web && pnpm test
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// ─── Mock pixi.js (minimal — the cache itself is pure math) ────────────────
+//
+// Only EdgesLayer / ParticlesLayer instantiation needs pixi primitives. The
+// shape mirrors the existing pixi/*-layer.test.ts mocks so importing those
+// layers does not throw.
+
+vi.mock('pixi.js', () => {
+  class MockContainer {
+    label = ''
+    children: unknown[] = []
+    addChild(child: unknown) { this.children.push(child) }
+    removeChild(child: unknown) {
+      const idx = this.children.indexOf(child)
+      if (idx >= 0) this.children.splice(idx, 1)
+    }
+    destroy() { this.children.length = 0 }
+  }
+
+  class MockBuffer {
+    data: Float32Array
+    _updates = 0
+    constructor(data: Float32Array) { this.data = data }
+    update() { this._updates++ }
+  }
+
+  class MockMeshGeometry {
+    positions: Float32Array
+    uvs: Float32Array
+    indices: Uint32Array
+    private _positionBuffer: MockBuffer
+    constructor(opts: { positions: Float32Array; uvs: Float32Array; indices: Uint32Array }) {
+      this.positions = opts.positions
+      this.uvs = opts.uvs
+      this.indices = opts.indices
+      this._positionBuffer = new MockBuffer(opts.positions)
+    }
+    getBuffer(name: string) {
+      if (name === 'aPosition') return this._positionBuffer
+      throw new Error(`unknown buffer ${name}`)
+    }
+    destroy(_destroyBuffers?: boolean) { /* no-op */ }
+  }
+
+  class MockMesh {
+    label = ''
+    tint = 0xffffff
+    alpha = 1
+    visible = true
+    geometry: MockMeshGeometry
+    texture: unknown
+    constructor(opts: { geometry: MockMeshGeometry; texture: unknown }) {
+      this.geometry = opts.geometry
+      this.texture = opts.texture
+    }
+    destroy(_opts?: unknown) { /* no-op */ }
+  }
+
+  class MockSprite {
+    label = ''
+    x = 0
+    y = 0
+    tint = 0xffffff
+    alpha = 1
+    visible = true
+    blendMode = 'normal'
+    texture: unknown
+    anchor = { set: () => {} }
+    scale = { set: () => {} }
+    constructor(texture?: unknown) { this.texture = texture }
+    destroy() { /* no-op */ }
+  }
+
+  class MockColor {
+    value: unknown = ''
+    toNumber() { return 0xffffff }
+  }
+
+  return {
+    Container: MockContainer,
+    Mesh: MockMesh,
+    MeshGeometry: MockMeshGeometry,
+    Sprite: MockSprite,
+    Color: MockColor,
+    Texture: { from: () => ({ destroy: () => {} }) },
+  }
+})
+
+// ─── Mock pixi-app texture helpers (used by particles-layer) ───────────────
+
+vi.mock('./pixi-app', () => ({
+  getCircleTexture: () => ({ destroy: () => {} }),
+  getGlowTexture: () => ({ destroy: () => {} }),
+}))
+
+// ─── Imports (after mocks) ─────────────────────────────────────────────────
+
+import {
+  BezierCache,
+  samplePolyline,
+  sharedBezierCache,
+  resetSharedBezierCache,
+  type BezierSample,
+  type CachedPolyline,
+} from './bezier-cache'
+import type { Agent, Edge, Particle, ToolCallNode } from '@/lib/agent-types'
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function makeAgent(id: string, x: number, y: number): Agent {
+  return {
+    id, name: id, x, y, opacity: 1,
+    state: 'thinking', color: '#66ccff',
+    isMain: true, scale: 1,
+    spawnTime: 0, tokensUsed: 0, tokensMax: 100000,
+    contextBreakdown: { systemPrompt: 0, userMessages: 0, toolResults: 0, reasoning: 0, subagentResults: 0 },
+    toolCalls: 0, timeAlive: 0, parentId: null,
+    messageBubbles: [],
+  } as unknown as Agent
+}
+
+function makeEdge(id: string, from: string, to: string): Edge {
+  return { id, from, to, type: 'parent-child', opacity: 1 } as Edge
+}
+
+function makeParticle(edgeId: string): Particle {
+  return {
+    id: `p-${edgeId}`,
+    edgeId,
+    progress: 0.5,
+    type: 'dispatch',
+    color: '#66ccff',
+    size: 3,
+    trailLength: 8,
+  }
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('bezier-cache module', () => {
+  beforeEach(() => {
+    resetSharedBezierCache()
+  })
+
+  // ─── IR-2: zero-allocation samplePolyline ───────────────────────────────
+
+  describe('samplePolyline (IR-2 scratch out-param)', () => {
+    function buildPolyline(): CachedPolyline {
+      // A polyline going straight along +x with a unit normal pointing +y.
+      // Sample i has x=10*i, y=0, nx=0, ny=1.
+      const n = 32
+      const samples: BezierSample[] = []
+      for (let i = 0; i <= n; i++) {
+        samples.push({ x: 10 * i, y: 0, nx: 0, ny: 1 })
+      }
+      return {
+        edgeId: 'e1',
+        fromX: 0, fromY: 0, toX: 320, toY: 0,
+        samples,
+        cp1x: 100, cp1y: 0, cp2x: 200, cp2y: 0,
+        dist: 320, dx: 320, dy: 0,
+      }
+    }
+
+    it('returns the SAME scratch reference every call (no allocation)', () => {
+      const polyline = buildPolyline()
+      const scratch: BezierSample = { x: 0, y: 0, nx: 0, ny: 0 }
+
+      // 1000 calls — if even one allocated, Object.is would fail.
+      for (let k = 0; k < 1000; k++) {
+        const t = (k % 100) / 100
+        const result = samplePolyline(polyline, t, scratch)
+        expect(Object.is(result, scratch)).toBe(true)
+      }
+    })
+
+    it('mutates scratch with the expected interpolated values', () => {
+      const polyline = buildPolyline()
+      const scratch: BezierSample = { x: 0, y: 0, nx: 0, ny: 0 }
+
+      // t=0 -> first sample exactly: (0, 0, 0, 1)
+      samplePolyline(polyline, 0, scratch)
+      expect(scratch.x).toBeCloseTo(0)
+      expect(scratch.y).toBeCloseTo(0)
+      expect(scratch.nx).toBeCloseTo(0)
+      expect(scratch.ny).toBeCloseTo(1)
+
+      // t=0.5 -> midpoint of polyline: x=160, y=0
+      samplePolyline(polyline, 0.5, scratch)
+      expect(scratch.x).toBeCloseTo(160)
+      expect(scratch.y).toBeCloseTo(0)
+
+      // t=1 -> clamps to last segment with frac=1: (320, 0, 0, 1)
+      samplePolyline(polyline, 1, scratch)
+      expect(scratch.x).toBeCloseTo(320)
+      expect(scratch.y).toBeCloseTo(0)
+    })
+
+    it('a SECOND scratch call overwrites the FIRST result (proves shared mutation)', () => {
+      // Pinning the documented contract: callers must consume the result
+      // before the next call, because there's only one scratch object.
+      const polyline = buildPolyline()
+      const scratch: BezierSample = { x: 0, y: 0, nx: 0, ny: 0 }
+
+      const first = samplePolyline(polyline, 0, scratch)
+      // Reading first.x before second call captures the t=0 value.
+      const firstXSnapshot = first.x
+
+      const second = samplePolyline(polyline, 1, scratch)
+      // After the second call, the same object now holds t=1's value.
+      expect(first).toBe(second)             // same reference
+      expect(first.x).toBeCloseTo(320)        // overwritten by t=1
+      expect(firstXSnapshot).toBeCloseTo(0)   // value captured before overwrite
+    })
+  })
+
+  // ─── IR-1: shared singleton ─────────────────────────────────────────────
+
+  describe('sharedBezierCache (IR-1 module-level singleton)', () => {
+    it('is a single BezierCache instance exported from the module', () => {
+      // Re-import via dynamic ESM to confirm the module returns the same
+      // instance — any path that produces a fresh BezierCache would break
+      // the cross-layer sharing the perf pass relied on.
+      expect(sharedBezierCache).toBeInstanceOf(BezierCache)
+    })
+
+    it('is shared between EdgesLayer and ParticlesLayer (single source of truth)', async () => {
+      const { EdgesLayer } = await import('./edges-layer')
+      const { ParticlesLayer } = await import('./particles-layer')
+
+      const agents = new Map<string, Agent>([
+        ['a1', makeAgent('a1', 0, 0)],
+        ['a2', makeAgent('a2', 200, 100)],
+      ])
+      const toolCalls = new Map<string, ToolCallNode>()
+      const edges = [makeEdge('e1', 'a1', 'a2')]
+      const particles = [makeParticle('e1')]
+
+      // Cache starts empty (resetSharedBezierCache in beforeEach).
+      expect(sharedBezierCache.size).toBe(0)
+
+      // EdgesLayer's update populates the singleton for 'e1'.
+      const edgesLayer = new EdgesLayer()
+      edgesLayer.update(edges, [], agents, toolCalls, 0)
+      const sizeAfterEdges = sharedBezierCache.size
+      expect(sizeAfterEdges).toBe(1)
+
+      // ParticlesLayer's update should reuse the same singleton entry,
+      // not create a duplicate. If each layer owned its own cache, the
+      // singleton would still report size 1 (because particles-layer
+      // would have its own private map), but the assertion below proves
+      // particles-layer wrote into the SAME module-level cache: pruning
+      // the singleton's set to {} would then evict the entry both layers
+      // share.
+      const particlesLayer = new ParticlesLayer()
+      particlesLayer.update(particles, edges, agents, toolCalls, 0)
+      expect(sharedBezierCache.size).toBe(1)
+
+      // Force-prune the singleton: if particles-layer used a private cache,
+      // its next update would not be affected; if it shares the singleton,
+      // the next get() rebuilds. We just confirm the singleton is the
+      // backing store for both by pruning to {}.
+      sharedBezierCache.prune(new Set<string>())
+      expect(sharedBezierCache.size).toBe(0)
+
+      // Now particles-layer's next update re-populates the SAME singleton
+      // (it has no other cache to fall back on).
+      particlesLayer.update(particles, edges, agents, toolCalls, 0.016)
+      expect(sharedBezierCache.size).toBe(1)
+    })
+
+    it('survives EdgesLayer dispose + re-instantiate (IR-1: dispose does NOT clear)', async () => {
+      // The principal explicitly preserved cache state across mount/remount
+      // cycles: "the shared bezier cache survives mount/remount cycles.
+      // That's intentional." A future "clear cache on dispose" change would
+      // silently undo the perf benefit; this test makes that regression
+      // visible.
+      const { EdgesLayer } = await import('./edges-layer')
+
+      const agents = new Map<string, Agent>([
+        ['a1', makeAgent('a1', 0, 0)],
+        ['a2', makeAgent('a2', 200, 100)],
+      ])
+      const toolCalls = new Map<string, ToolCallNode>()
+      const edges = [makeEdge('e1', 'a1', 'a2')]
+
+      // Phase 1: populate.
+      const layer1 = new EdgesLayer()
+      layer1.update(edges, [], agents, toolCalls, 0)
+      expect(sharedBezierCache.size).toBe(1)
+
+      // Phase 2: dispose. The cache MUST NOT be cleared.
+      layer1.dispose()
+      expect(sharedBezierCache.size).toBe(1)
+
+      // Phase 3: re-instantiate. The new layer can read the still-warm
+      // cache without re-sampling the bezier curve from scratch.
+      const layer2 = new EdgesLayer()
+      // Without calling update(), the cache should still have 'e1'.
+      expect(sharedBezierCache.size).toBe(1)
+      // Sanity: the new layer can still update normally.
+      layer2.update(edges, [], agents, toolCalls, 0.016)
+      expect(sharedBezierCache.size).toBe(1)
+    })
+  })
+})

--- a/web/components/agent-visualizer/pixi/bezier-cache.ts
+++ b/web/components/agent-visualizer/pixi/bezier-cache.ts
@@ -159,10 +159,12 @@ export class BezierCache {
 }
 
 /** Interpolate a position along the precomputed polyline at parameter t (0..1).
- *  Returns the interpolated {x, y, nx, ny} by lerping between the two nearest
- *  samples. Cheaper than evaluating the cubic polynomial. */
+ *  Mutates and returns `out` with the interpolated {x, y, nx, ny} by lerping
+ *  between the two nearest samples. Cheaper than evaluating the cubic
+ *  polynomial. The out-parameter form lets the hot path (particles-layer)
+ *  reuse a single scratch object across thousands of calls per frame. */
 export function samplePolyline(
-  polyline: CachedPolyline, t: number,
+  polyline: CachedPolyline, t: number, out: BezierSample,
 ): BezierSample {
   const n = polyline.samples.length - 1
   const idx = t * n
@@ -171,10 +173,22 @@ export function samplePolyline(
   const frac = idx - i0
   const a = polyline.samples[i0]
   const b = polyline.samples[i1]
-  return {
-    x: a.x + (b.x - a.x) * frac,
-    y: a.y + (b.y - a.y) * frac,
-    nx: a.nx + (b.nx - a.nx) * frac,
-    ny: a.ny + (b.ny - a.ny) * frac,
-  }
+  out.x = a.x + (b.x - a.x) * frac
+  out.y = a.y + (b.y - a.y) * frac
+  out.nx = a.nx + (b.nx - a.nx) * frac
+  out.ny = a.ny + (b.ny - a.ny) * frac
+  return out
+}
+
+/**
+ * Module-level singleton shared by EdgesLayer and ParticlesLayer. Both layers
+ * compute polyline samples for the same edges; sharing the cache avoids
+ * redundant bezier evaluation each frame and keeps a single source of truth
+ * for invalidation timing.
+ */
+export const sharedBezierCache = new BezierCache()
+
+/** Test helper — clears the shared cache between test runs. */
+export function resetSharedBezierCache(): void {
+  sharedBezierCache.clear()
 }

--- a/web/components/agent-visualizer/pixi/bubbles-layer.test.ts
+++ b/web/components/agent-visualizer/pixi/bubbles-layer.test.ts
@@ -49,10 +49,16 @@ vi.mock('pixi.js', () => {
   class MockGraphics {
     label = ''
     visible = true
-    clear() { return this }
-    roundRect() { return this }
-    fill(_opts: unknown) { return this }
-    stroke(_opts: unknown) { return this }
+    // Per-instance counters added for IR-6 background-rebuild gating.
+    // Existing tests do not inspect these fields and are unaffected.
+    _clearCount = 0
+    _roundRectCount = 0
+    _fillCount = 0
+    _strokeCount = 0
+    clear() { this._clearCount++; return this }
+    roundRect() { this._roundRectCount++; return this }
+    fill(_opts: unknown) { this._fillCount++; return this }
+    stroke(_opts: unknown) { this._strokeCount++; return this }
     destroy() { /* no-op */ }
   }
 
@@ -221,5 +227,84 @@ describe('BubblesLayer', () => {
     layer.dispose()
     expect(layer.activeCount).toBe(0)
     expect(layer.freeCount).toBe(0)
+  })
+
+  // ─── IR-3: wrap-cache hit on stable bubble ───────────────────────────────
+  // The pre-fix renderer ran the full word-wrap loop every frame, even
+  // though the text and dimensions never changed. The post-fix path stores
+  // the wrapped lines on the MessageBubble itself (`_cachedWrappedLines`)
+  // and reuses the SAME ARRAY across frames whenever the wrap key matches.
+  //
+  // A regression that drops the cache, mis-keys it, or rebuilds the array
+  // every frame would fail the strict reference-equality check below.
+
+  it('IR-3: _cachedWrappedLines populates after first frame and is the same array across 10 frames', () => {
+    const layer = new BubblesLayer()
+    const longText = 'The quick brown fox jumps over the lazy dog. '.repeat(4).trim()
+    const bubble = makeBubble(0, longText)
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1', [bubble])],
+    ])
+
+    // Frame 1 — populate the cache.
+    layer.update(agents, 0.1)
+    const cachedAfterFrame1 = bubble._cachedWrappedLines
+    expect(cachedAfterFrame1).toBeDefined()
+    expect(cachedAfterFrame1!.length).toBeGreaterThan(0)
+    // The cache key uses a 'pixi:' prefix so it doesn't collide with the
+    // canvas2d path's font-string key.
+    expect(bubble._cachedWrappedFont).toMatch(/^pixi:/)
+
+    // Capture the full content snapshot to compare against later frames.
+    const linesSnapshot = [...cachedAfterFrame1!]
+
+    for (let frame = 2; frame <= 10; frame++) {
+      layer.update(agents, 0.1 + frame * 0.016)
+      // Reference equality: same array, not just same content.
+      expect(bubble._cachedWrappedLines).toBe(cachedAfterFrame1)
+    }
+
+    // Content sanity — neither length nor any line drifted across frames.
+    expect(bubble._cachedWrappedLines).toEqual(linesSnapshot)
+  })
+
+  // ─── IR-6: background-rebuild gating on stable bubble ────────────────────
+  // Bubbles don't pulse, so a stable bubble (constant text + role) should
+  // rebuild its background Graphics exactly once across many frames. Pre-fix
+  // every frame ran clear+roundRect+fill+stroke; post-fix gates on
+  // bgKey = `${bubbleW}|${bubbleH}|${role}` which is immutable for stable
+  // input.
+
+  it('IR-6: stable bubble rebuilds background exactly once across 30 frames', () => {
+    const layer = new BubblesLayer()
+    const bubble = makeBubble(0, 'Hello world from the bubble layer test', 'assistant')
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1', [bubble])],
+    ])
+
+    // First update: spawn the entry.
+    layer.update(agents, 0.1)
+
+    // Reach into the layer to grab the active entry's background Graphics.
+    const pool = (layer as unknown as {
+      pool: { active: Map<string, { background: { _clearCount: number; _roundRectCount: number; _fillCount: number; _strokeCount: number } }> }
+    }).pool
+    expect(pool.active.size).toBe(1)
+    const entry = Array.from(pool.active.values())[0]
+    const bg = entry.background
+    const initialClears = bg._clearCount
+    const initialRoundRects = bg._roundRectCount
+    const initialFills = bg._fillCount
+    const initialStrokes = bg._strokeCount
+
+    // 30 stable frames — bgKey unchanged → no background rebuilds.
+    for (let frame = 1; frame <= 30; frame++) {
+      layer.update(agents, 0.1 + frame * 0.016)
+    }
+
+    expect(bg._clearCount - initialClears).toBe(0)
+    expect(bg._roundRectCount - initialRoundRects).toBe(0)
+    expect(bg._fillCount - initialFills).toBe(0)
+    expect(bg._strokeCount - initialStrokes).toBe(0)
   })
 })

--- a/web/components/agent-visualizer/pixi/bubbles-layer.ts
+++ b/web/components/agent-visualizer/pixi/bubbles-layer.ts
@@ -39,6 +39,9 @@ interface BubbleEntry {
   lastContentKey: string
   /** Cache key for role label. */
   lastLabelKey: string
+  /** Cache key for the background Graphics commands. Bubbles don't pulse,
+   *  so the inputs are just dimensions and role. (IR-6) */
+  lastBgKey: string
 }
 
 /** Pool of reusable bubble entries. */
@@ -101,23 +104,36 @@ export class BubblesLayer {
         const charW = approxCharW(style.fontSize)
         const maxCharsPerLine = Math.floor((BUBBLE_MAX_W - style.padding * 2 - 4) / charW)
 
-        // Simple line wrapping (approximation of Canvas2D wrapText)
-        const rawLines = text.split('\n')
-        const allLines: string[] = []
-        for (const para of rawLines) {
-          if (para.trim() === '') { allLines.push(''); continue }
-          const words = para.split(/\s+/)
-          let line = ''
-          for (const word of words) {
-            const test = line ? `${line} ${word}` : word
-            if (test.length > maxCharsPerLine && line) {
-              allLines.push(line)
-              line = word
-            } else {
-              line = test
+        // IR-3: cache the wrapped lines on the bubble itself so subsequent
+        // frames skip the rawLines.split + word loop. The cache key has
+        // a "pixi:" prefix so it doesn't collide with the canvas2d path's
+        // font-string key (`'12px monospace'`) on the same MessageBubble
+        // when both renderers run side-by-side.
+        const wrapKey = `pixi:${maxCharsPerLine}`
+        let allLines: string[]
+        if (bubble._cachedWrappedLines && bubble._cachedWrappedFont === wrapKey) {
+          allLines = bubble._cachedWrappedLines
+        } else {
+          // Simple line wrapping (approximation of Canvas2D wrapText)
+          const rawLines = text.split('\n')
+          allLines = []
+          for (const para of rawLines) {
+            if (para.trim() === '') { allLines.push(''); continue }
+            const words = para.split(/\s+/)
+            let line = ''
+            for (const word of words) {
+              const test = line ? `${line} ${word}` : word
+              if (test.length > maxCharsPerLine && line) {
+                allLines.push(line)
+                line = word
+              } else {
+                line = test
+              }
             }
+            if (line) allLines.push(line)
           }
-          if (line) allLines.push(line)
+          bubble._cachedWrappedLines = allLines
+          bubble._cachedWrappedFont = wrapKey
         }
 
         const truncated = allLines.length > BUBBLE_MAX_LINES
@@ -139,6 +155,12 @@ export class BubblesLayer {
           entry.container.visible = true
           entry.container.label = `bubble-${agent.id}`
           entry.container.eventMode = 'static'
+          // A pooled entry carries its previous bubble's cache keys.
+          // Reset them so the upcoming render re-emits all glyphs and
+          // background commands for the new bubble's content.
+          entry.lastContentKey = ''
+          entry.lastLabelKey = ''
+          entry.lastBgKey = ''
         }
 
         // ── Position + alpha ────────────────────────────────────────
@@ -148,12 +170,20 @@ export class BubblesLayer {
         entry.container.visible = true
 
         // ── Background ──────────────────────────────────────────────
+        // IR-6: gate on a key over the inputs (bubbleW/H/role drive every
+        // command on the Graphics object). Skipping the rebuild when nothing
+        // visual has changed avoids the per-frame clear+roundRect+fill+stroke
+        // chain — typical sessions have hundreds of bubbles.
         const bgColor = this.getBubbleBgTint(role)
         const bgAlpha = isThinking ? 0.08 : 0.12
-        entry.background.clear()
-        entry.background.roundRect(0, 0, bubbleW, bubbleH, BUBBLE_DRAW.borderRadius)
-        entry.background.fill({ color: bgColor, alpha: bgAlpha })
-        entry.background.stroke({ width: 0.5, color: bgColor, alpha: isThinking ? 0.15 : 0.25 })
+        const bgKey = `${bubbleW}|${bubbleH}|${role}`
+        if (bgKey !== entry.lastBgKey) {
+          entry.background.clear()
+          entry.background.roundRect(0, 0, bubbleW, bubbleH, BUBBLE_DRAW.borderRadius)
+          entry.background.fill({ color: bgColor, alpha: bgAlpha })
+          entry.background.stroke({ width: 0.5, color: bgColor, alpha: isThinking ? 0.15 : 0.25 })
+          entry.lastBgKey = bgKey
+        }
 
         // ── Role label ──────────────────────────────────────────────
         const labelStr = isThinking ? 'THINKING' : role === 'user' ? 'USER' : 'CLAUDE'
@@ -270,6 +300,7 @@ export class BubblesLayer {
       contentSprites: [],
       lastContentKey: '',
       lastLabelKey: '',
+      lastBgKey: '',
     }
   }
 

--- a/web/components/agent-visualizer/pixi/discoveries-layer.test.ts
+++ b/web/components/agent-visualizer/pixi/discoveries-layer.test.ts
@@ -179,16 +179,21 @@ describe('DiscoveriesLayer', () => {
     expect(layer.entryCount).toBe(0)
   })
 
-  it('discoveries that disappear between frames are hidden', () => {
+  it('destroys entries for discoveries that disappear between frames', () => {
+    // Stale-id sweep (CR-3): discovery entries are destroyed when their id
+    // no longer appears in the input. Previously entries were merely hidden,
+    // leaking GPU buffers over long sessions.
     const layer = new DiscoveriesLayer()
     const agents = new Map<string, Agent>([['a1', makeAgent('a1')]])
 
     layer.update([makeDiscovery('d1'), makeDiscovery('d2')], agents)
     expect(layer.getEntry('d1')!.container.visible).toBe(true)
     expect(layer.getEntry('d2')!.container.visible).toBe(true)
+    expect(layer.entryCount).toBe(2)
 
     layer.update([makeDiscovery('d1')], agents)
     expect(layer.getEntry('d1')!.container.visible).toBe(true)
-    expect(layer.getEntry('d2')!.container.visible).toBe(false)
+    expect(layer.getEntry('d2')).toBeUndefined()
+    expect(layer.entryCount).toBe(1)
   })
 })

--- a/web/components/agent-visualizer/pixi/discoveries-layer.test.ts
+++ b/web/components/agent-visualizer/pixi/discoveries-layer.test.ts
@@ -52,13 +52,20 @@ vi.mock('pixi.js', () => {
     _cleared = false
     _moveToCount = 0
     _lineToCount = 0
-    clear() { this._cleared = true; this._moveToCount = 0; this._lineToCount = 0; return this }
-    roundRect() { return this }
+    // Per-instance counters added for IR-5 (stroke count == bucket count)
+    // and IR-6 (background rebuild gating). Existing tests are unaffected
+    // because they only inspect _cleared / _moveToCount / _lineToCount.
+    _clearCount = 0
+    _roundRectCount = 0
+    _fillCount = 0
+    _strokeCount = 0
+    clear() { this._cleared = true; this._moveToCount = 0; this._lineToCount = 0; this._clearCount++; return this }
+    roundRect() { this._roundRectCount++; return this }
     rect() { return this }
     moveTo() { this._moveToCount++; return this }
     lineTo() { this._lineToCount++; return this }
-    fill(_opts: unknown) { return this }
-    stroke(_opts: unknown) { return this }
+    fill(_opts: unknown) { this._fillCount++; return this }
+    stroke(_opts: unknown) { this._strokeCount++; return this }
     destroy() { /* no-op */ }
   }
 
@@ -195,5 +202,105 @@ describe('DiscoveriesLayer', () => {
     expect(layer.getEntry('d1')!.container.visible).toBe(true)
     expect(layer.getEntry('d2')).toBeUndefined()
     expect(layer.entryCount).toBe(1)
+  })
+
+  // ─── CR-3: leak prevention with destroy() spy across multi-frame window ──
+
+  it('CR-3: 5 discoveries stable for 3 frames then absent → entries destroyed and dropped', () => {
+    const layer = new DiscoveriesLayer()
+    const agents = new Map<string, Agent>([['a1', makeAgent('a1')]])
+    const discoveries = [
+      makeDiscovery('d1'),
+      makeDiscovery('d2'),
+      makeDiscovery('d3'),
+      makeDiscovery('d4'),
+      makeDiscovery('d5'),
+    ]
+
+    layer.update(discoveries, agents)
+    layer.update(discoveries, agents)
+    layer.update(discoveries, agents)
+    expect(layer.entryCount).toBe(5)
+
+    const destroySpies = ['d1', 'd2', 'd3', 'd4', 'd5'].map(id => {
+      const entry = layer.getEntry(id)!
+      return vi.spyOn(entry.container, 'destroy')
+    })
+
+    layer.update([], agents)
+    expect(layer.entryCount).toBe(0)
+    for (const spy of destroySpies) {
+      expect(spy).toHaveBeenCalled()
+    }
+  })
+
+  // ─── IR-5: alpha-bucketed connection-line strokes ────────────────────────
+  // Pre-fix the connection-line draw path issued one stroke() per discovery,
+  // producing O(n) draw calls. Post-fix discoveries are bucketed by quantized
+  // alpha (round(opacity*0.09*20)/20, range {0, 0.05, 0.10}) and stroke()
+  // runs once per non-empty bucket — independent of n.
+  //
+  // The 10 opacities below land in 3 distinct buckets:
+  //   { 0.15, 0.20 } → bucket 0
+  //   { 0.40, 0.50, 0.60, 0.70 } → bucket 0.05
+  //   { 0.85, 0.90, 0.95, 1.00 } → bucket 0.10
+  // → exactly 3 stroke() calls regardless of the 10 input discoveries.
+
+  it('IR-5: stroke() called once per alpha bucket on connectionLines, not once per discovery', () => {
+    const layer = new DiscoveriesLayer()
+    const agents = new Map<string, Agent>([['a1', makeAgent('a1', 0, 0)]])
+    const opacities = [0.15, 0.20, 0.40, 0.50, 0.60, 0.70, 0.85, 0.90, 0.95, 1.00]
+    const discoveries = opacities.map((opacity, i) =>
+      makeDiscovery(`d${i}`, { opacity, x: 100 + i * 10, y: 100 }),
+    )
+
+    // Reach into the layer for the connectionLines Graphics (private but
+    // an implementation detail of the perf invariant we're testing).
+    const connectionLines = (layer as unknown as {
+      connectionLines: { _strokeCount: number }
+    }).connectionLines
+    const strokesBefore = connectionLines._strokeCount
+
+    layer.update(discoveries, agents)
+
+    const strokesDuringFrame = connectionLines._strokeCount - strokesBefore
+    // Exactly 3 distinct alpha buckets → 3 stroke() calls. A regression to
+    // per-discovery stroking would jump to 10.
+    expect(strokesDuringFrame).toBe(3)
+  })
+
+  // ─── IR-6: background-rebuild gating ─────────────────────────────────────
+  // Discoveries don't pulse, so a stable discovery should rebuild its
+  // background and accent-bar Graphics exactly once across many frames.
+  // Pre-fix every frame ran clear+roundRect+fill+stroke; post-fix gates on
+  // bgKey = `${cardW}|${cardH}|${typeColor}|${isSelected}` which is
+  // immutable for a stable input.
+
+  it('IR-6: stable discovery rebuilds background Graphics exactly once across 30 frames', () => {
+    const layer = new DiscoveriesLayer()
+    const agents = new Map<string, Agent>([['a1', makeAgent('a1')]])
+    const discoveries = [makeDiscovery('d1')]
+
+    // First update creates the entry; capture initial counters AFTER that.
+    layer.update(discoveries, agents)
+    const entry = layer.getEntry('d1')!
+    const bg = entry.background as unknown as {
+      _clearCount: number
+      _roundRectCount: number
+      _fillCount: number
+      _strokeCount: number
+    }
+    const initialClears = bg._clearCount
+    const initialRoundRects = bg._roundRectCount
+    const initialFills = bg._fillCount
+
+    // 30 stable frames — bgKey unchanged, so no rebuilds.
+    for (let frame = 1; frame <= 30; frame++) {
+      layer.update(discoveries, agents)
+    }
+
+    expect(bg._clearCount - initialClears).toBe(0)
+    expect(bg._roundRectCount - initialRoundRects).toBe(0)
+    expect(bg._fillCount - initialFills).toBe(0)
   })
 })

--- a/web/components/agent-visualizer/pixi/discoveries-layer.ts
+++ b/web/components/agent-visualizer/pixi/discoveries-layer.ts
@@ -191,10 +191,14 @@ export class DiscoveriesLayer {
       }
     }
 
-    // Hide entries for discoveries that no longer exist
+    // Drop entries for discoveries that no longer exist this frame.
+    // Discoveries with opacity < 0.05 are skipped earlier in the loop, so
+    // they fall out of aliveIds and get destroyed here. Previously entries
+    // were merely hidden, leaking GPU buffers across long sessions.
     for (const [id, entry] of this.entries) {
       if (!aliveIds.has(id)) {
-        entry.container.visible = false
+        entry.container.destroy({ children: true })
+        this.entries.delete(id)
       }
     }
   }

--- a/web/components/agent-visualizer/pixi/discoveries-layer.ts
+++ b/web/components/agent-visualizer/pixi/discoveries-layer.ts
@@ -31,6 +31,10 @@ interface DiscoveryEntry {
   lastLabelText: string
   lastLabelColor: string
   lastContentKey: string
+  /** Cache key for background + accent-bar Graphics commands. Both share
+   *  the same dependency set (cardW, cardH, typeColor, isSelected) so they
+   *  rebuild together. (IR-6) */
+  lastBgKey: string
   discoveryId: string
 }
 
@@ -41,6 +45,19 @@ function parseColor(hex: string): number {
   }
   return 0xffffff
 }
+
+/** Pre-parsed tint for connection lines — the same color string is used
+ *  for every discovery, so parsing once at module load is strictly cheaper
+ *  than parsing per-frame. */
+const HOLO_BASE_TINT = parseColor(COLORS.holoBase)
+
+/**
+ * Module-scope reusable bucket map for IR-5 alpha-bucketed connection-line
+ * drawing. Keyed by quantized alpha (Math.round(alpha * 20) / 20). Each value
+ * is a flat array of [ax, ay, dx, dy, …] coordinates. Reused across frames:
+ * we clear each value's length to 0 instead of allocating a fresh Map.
+ */
+const CONNECTION_BUCKETS = new Map<number, number[]>()
 
 /**
  * Manages the discovery rendering layer. Owns a Container that the caller
@@ -75,17 +92,38 @@ export class DiscoveriesLayer {
     const aliveIds = new Set<string>()
 
     // ── Connection lines ────────────────────────────────────────────────
+    // IR-5: bucket by quantized alpha so each unique alpha emits one
+    // moveTo+lineTo+stroke draw call instead of N. Discoveries' opacity is
+    // continuous, but quantizing the resulting alpha to 1/20 increments
+    // collapses ~all per-frame variation into a handful of buckets.
     this.connectionLines.clear()
+
+    // Reset existing bucket arrays in place (no Map allocation per frame).
+    for (const arr of CONNECTION_BUCKETS.values()) arr.length = 0
+
     for (const disc of discoveries) {
       const agent = agents.get(disc.agentId)
       if (!agent || disc.opacity < 0.1) continue
 
-      this.connectionLines.moveTo(agent.x, agent.y)
-      this.connectionLines.lineTo(disc.x, disc.y)
+      const alphaBucket = Math.round(disc.opacity * 0.09 * 20) / 20
+      let arr = CONNECTION_BUCKETS.get(alphaBucket)
+      if (!arr) {
+        arr = []
+        CONNECTION_BUCKETS.set(alphaBucket, arr)
+      }
+      arr.push(agent.x, agent.y, disc.x, disc.y)
+    }
+
+    for (const [alpha, coords] of CONNECTION_BUCKETS) {
+      if (coords.length === 0) continue
+      for (let i = 0; i < coords.length; i += 4) {
+        this.connectionLines.moveTo(coords[i], coords[i + 1])
+        this.connectionLines.lineTo(coords[i + 2], coords[i + 3])
+      }
       this.connectionLines.stroke({
         width: 0.5,
-        color: parseColor(COLORS.holoBase),
-        alpha: disc.opacity * 0.09,
+        color: HOLO_BASE_TINT,
+        alpha,
       })
     }
 
@@ -113,21 +151,28 @@ export class DiscoveriesLayer {
       entry.container.alpha = disc.opacity
       entry.container.visible = disc.opacity > 0.01
 
-      // ── Background ────────────────────────────────────────────────
-      entry.background.clear()
-      entry.background.roundRect(-cardW / 2, -cardH / 2, cardW, cardH, 3)
-      entry.background.fill({
-        color: isSelected ? parseColor('#0a0f1e') : parseColor('#0a0f1e'),
-        alpha: isSelected ? 0.8 : 0.6,
-      })
-      if (!isSelected) {
-        entry.background.stroke({ width: 0.5, color: typeTint, alpha: 0.19 })
-      }
+      // ── Background + accent bar ──────────────────────────────────
+      // IR-6: gate the Graphics rebuild on a key over every input that
+      // affects the rendered shape. Discoveries don't pulse, so the key
+      // is just the geometry + state inputs.
+      const bgKey = `${cardW}|${cardH}|${typeColor}|${isSelected}`
+      if (bgKey !== entry.lastBgKey) {
+        entry.background.clear()
+        entry.background.roundRect(-cardW / 2, -cardH / 2, cardW, cardH, 3)
+        entry.background.fill({
+          color: parseColor('#0a0f1e'),
+          alpha: isSelected ? 0.8 : 0.6,
+        })
+        if (!isSelected) {
+          entry.background.stroke({ width: 0.5, color: typeTint, alpha: 0.19 })
+        }
 
-      // ── Accent bar ────────────────────────────────────────────────
-      entry.accentBar.clear()
-      entry.accentBar.rect(-cardW / 2, -cardH / 2, 2, cardH)
-      entry.accentBar.fill({ color: typeTint, alpha: 0.375 })
+        entry.accentBar.clear()
+        entry.accentBar.rect(-cardW / 2, -cardH / 2, 2, cardH)
+        entry.accentBar.fill({ color: typeTint, alpha: 0.375 })
+
+        entry.lastBgKey = bgKey
+      }
 
       // ── Selection glow ────────────────────────────────────────────
       entry.selectionGlow.visible = isSelected
@@ -256,6 +301,7 @@ export class DiscoveriesLayer {
       lastLabelText: '',
       lastLabelColor: '',
       lastContentKey: '',
+      lastBgKey: '',
       discoveryId,
     }
   }

--- a/web/components/agent-visualizer/pixi/edges-layer.test.ts
+++ b/web/components/agent-visualizer/pixi/edges-layer.test.ts
@@ -64,13 +64,25 @@ const { mockBezierCacheGet, mockBezierCachePrune, mockBezierCacheClear } = vi.ho
   mockBezierCacheClear: vi.fn(),
 }))
 
-vi.mock('./bezier-cache', () => ({
-  BezierCache: class {
-    get = mockBezierCacheGet
-    prune = mockBezierCachePrune
-    clear = mockBezierCacheClear
-  },
-}))
+vi.mock('./bezier-cache', () => {
+  // Singleton instance shared by edges-layer and particles-layer in production.
+  // The test exposes the same handle so assertions can verify shared usage.
+  const sharedBezierCache = {
+    get: mockBezierCacheGet,
+    prune: mockBezierCachePrune,
+    clear: mockBezierCacheClear,
+  }
+  return {
+    BezierCache: class {
+      get = mockBezierCacheGet
+      prune = mockBezierCachePrune
+      clear = mockBezierCacheClear
+    },
+    sharedBezierCache,
+    resetSharedBezierCache: () => mockBezierCacheClear(),
+    samplePolyline: (_polyline: unknown, _t: number, out: { x: number; y: number; nx: number; ny: number }) => out,
+  }
+})
 
 // ─── Mock canvas/draw-edges ────────────────────────────────────────────────
 

--- a/web/components/agent-visualizer/pixi/edges-layer.test.ts
+++ b/web/components/agent-visualizer/pixi/edges-layer.test.ts
@@ -14,12 +14,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // vi.mock factories are hoisted — all definitions must be self-contained.
 
 vi.mock('pixi.js', () => {
-  class MockPoint {
-    x: number
-    y: number
-    constructor(x = 0, y = 0) { this.x = x; this.y = y }
-  }
-
   class MockContainer {
     label = ''
     children: unknown[] = []
@@ -31,26 +25,51 @@ vi.mock('pixi.js', () => {
     destroy() { this.children.length = 0 }
   }
 
-  class MockMeshRope {
+  // Minimal Buffer.update() / getBuffer() surface so the layer's
+  // `geometry.getBuffer('aPosition').update()` call works in jsdom.
+  class MockBuffer {
+    data: Float32Array
+    _updates = 0
+    constructor(data: Float32Array) { this.data = data }
+    update() { this._updates++ }
+  }
+
+  class MockMeshGeometry {
+    positions: Float32Array
+    uvs: Float32Array
+    indices: Uint32Array
+    private _positionBuffer: MockBuffer
+    constructor(opts: { positions: Float32Array; uvs: Float32Array; indices: Uint32Array }) {
+      this.positions = opts.positions
+      this.uvs = opts.uvs
+      this.indices = opts.indices
+      this._positionBuffer = new MockBuffer(opts.positions)
+    }
+    getBuffer(name: string) {
+      if (name === 'aPosition') return this._positionBuffer
+      throw new Error(`unknown buffer ${name}`)
+    }
+    destroy(_destroyBuffers?: boolean) { /* no-op */ }
+  }
+
+  class MockMesh {
     label = ''
     tint = 0xffffff
     alpha = 1
     visible = true
+    geometry: MockMeshGeometry
     texture: unknown
-    points: InstanceType<typeof MockPoint>[]
-    width: number
-    constructor(opts: { texture: unknown; points: InstanceType<typeof MockPoint>[]; width?: number }) {
+    constructor(opts: { geometry: MockMeshGeometry; texture: unknown }) {
+      this.geometry = opts.geometry
       this.texture = opts.texture
-      this.points = opts.points
-      this.width = opts.width ?? 1
     }
-    destroy() { /* no-op */ }
+    destroy(_opts?: unknown) { /* no-op */ }
   }
 
   return {
     Container: MockContainer,
-    MeshRope: MockMeshRope,
-    Point: MockPoint,
+    Mesh: MockMesh,
+    MeshGeometry: MockMeshGeometry,
     Texture: { from: () => ({ destroy: () => {} }) },
   }
 })
@@ -245,7 +264,7 @@ describe('EdgesLayer', () => {
     // BEAM.activeAlpha = 0.3, BEAM.idleAlpha = 0.08
     // Active alpha is modulated by pulsing: sin(0 * 4) * 0.1 + 0.9 = 0.9
     // So active alpha = 0.3 * 0.9 = 0.27, idle = 0.08 * 1 = 0.08
-    expect(activeEntry!.rope.alpha).toBeGreaterThan(idleEntry!.rope.alpha)
+    expect(activeEntry!.mesh.alpha).toBeGreaterThan(idleEntry!.mesh.alpha)
   })
 
   it('active edges get the correct tint for their type', () => {
@@ -268,12 +287,15 @@ describe('EdgesLayer', () => {
     const toolEntry = layer.getEntry('e2')
 
     // COLORS.holoBase = '#66ccff' -> 0x66ccff
-    expect(parentChildEntry!.rope.tint).toBe(0x66ccff)
+    expect(parentChildEntry!.mesh.tint).toBe(0x66ccff)
     // COLORS.tool = '#ffbb44' -> 0xffbb44
-    expect(toolEntry!.rope.tint).toBe(0xffbb44)
+    expect(toolEntry!.mesh.tint).toBe(0xffbb44)
   })
 
-  it('hides ropes for edges that disappear between frames', () => {
+  it('destroys mesh entries for edges that disappear between frames', () => {
+    // Stale-id sweep (CR-3): when an edge id no longer appears in the
+    // current frame's input, its entry is destroyed and removed from the
+    // map — preventing the previously unbounded growth of hidden meshes.
     const layer = new EdgesLayer()
     const agents = new Map<string, Agent>([
       ['a1', makeAgent('a1', 0, 0)],
@@ -286,15 +308,17 @@ describe('EdgesLayer', () => {
       [makeEdge('e1', 'a1', 'a2'), makeEdge('e2', 'a1', 'a3')],
       [], agents, new Map(), 0,
     )
-    expect(layer.getEntry('e1')!.rope.visible).toBe(true)
-    expect(layer.getEntry('e2')!.rope.visible).toBe(true)
+    expect(layer.getEntry('e1')!.mesh.visible).toBe(true)
+    expect(layer.getEntry('e2')!.mesh.visible).toBe(true)
+    expect(layer.entryCount).toBe(2)
 
-    // Frame 2: only e1 remains
+    // Frame 2: only e1 remains — e2 entry should be destroyed and removed
     layer.update(
       [makeEdge('e1', 'a1', 'a2')],
       [], agents, new Map(), 1,
     )
-    expect(layer.getEntry('e1')!.rope.visible).toBe(true)
-    expect(layer.getEntry('e2')!.rope.visible).toBe(false)
+    expect(layer.getEntry('e1')!.mesh.visible).toBe(true)
+    expect(layer.getEntry('e2')).toBeUndefined()
+    expect(layer.entryCount).toBe(1)
   })
 })

--- a/web/components/agent-visualizer/pixi/edges-layer.test.ts
+++ b/web/components/agent-visualizer/pixi/edges-layer.test.ts
@@ -321,4 +321,161 @@ describe('EdgesLayer', () => {
     expect(layer.getEntry('e2')).toBeUndefined()
     expect(layer.entryCount).toBe(1)
   })
+
+  // ─── CR-1: vertex-offset width assertions ────────────────────────────────
+  // The previous MeshRope path silently ignored the `width` constructor
+  // option; every edge rendered at the rope texture's native height. The
+  // current strip Mesh encodes width directly into the geometry by placing
+  // top/bottom vertices at ±halfWidth along the precomputed sample normal.
+  // These tests pin down that contract: they read the raw vertex buffer and
+  // assert the exact offsets. A regression to MeshRope (or any geometry
+  // that ignores the per-edge-type half-width) would fail here.
+
+  it('CR-1: parent-child edges place top/bottom vertices ±1.5 along the sample normal', () => {
+    // BEAM.parentChild.startW = 3 → halfWidth = 1.5
+    const layer = new EdgesLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1', 0, 0)],
+      ['a2', makeAgent('a2', 320, 160)],
+    ])
+    const edges = [makeEdge('e1', 'a1', 'a2', 'parent-child')]
+
+    layer.update(edges, [], agents, new Map(), 0)
+
+    const entry = layer.getEntry('e1')!
+    const buffer = entry.mesh.geometry.getBuffer('aPosition') as unknown as { data: Float32Array }
+    const positions = buffer.data
+    expect(positions.length).toBe(mockPolylineSamples.length * 4)
+
+    // Sample three indices spanning the polyline; assert offsets are
+    // EXACTLY ±halfWidth * normal (mockPolylineSamples have nx=0, ny=1).
+    const halfW = 1.5
+    for (const i of [0, 10, mockPolylineSamples.length - 1]) {
+      const s = mockPolylineSamples[i]
+      const o = i * 4
+      const topX = positions[o + 0]
+      const topY = positions[o + 1]
+      const botX = positions[o + 2]
+      const botY = positions[o + 3]
+      // top  = (s.x + nx*halfW, s.y + ny*halfW)
+      // bot  = (s.x - nx*halfW, s.y - ny*halfW)
+      expect(topX).toBeCloseTo(s.x + s.nx * halfW)
+      expect(topY).toBeCloseTo(s.y + s.ny * halfW)
+      expect(botX).toBeCloseTo(s.x - s.nx * halfW)
+      expect(botY).toBeCloseTo(s.y - s.ny * halfW)
+      // Euclidean distance between top and bot must equal beamWidth (3).
+      const dx = topX - botX
+      const dy = topY - botY
+      expect(Math.sqrt(dx * dx + dy * dy)).toBeCloseTo(3)
+    }
+  })
+
+  it('CR-1: tool edges place top/bottom vertices ±0.75 along the sample normal', () => {
+    // BEAM.tool.startW = 1.5 → halfWidth = 0.75. A regression that
+    // re-introduces a single rope width across edge types would still pass
+    // the parent-child test above; this asserts the per-type discrimination.
+    const layer = new EdgesLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1', 0, 0)],
+    ])
+    const toolCalls = new Map<string, ToolCallNode>([
+      ['t1', makeToolCall('t1', 200, 100)],
+    ])
+    const edges = [makeEdge('e1', 'a1', 't1', 'tool')]
+
+    layer.update(edges, [], agents, toolCalls, 0)
+
+    const entry = layer.getEntry('e1')!
+    const buffer = entry.mesh.geometry.getBuffer('aPosition') as unknown as { data: Float32Array }
+    const positions = buffer.data
+    const halfW = 0.75
+    for (const i of [0, 16, mockPolylineSamples.length - 1]) {
+      const s = mockPolylineSamples[i]
+      const o = i * 4
+      // The Euclidean width for tool edges must be 1.5, not 3.
+      const topX = positions[o + 0]
+      const topY = positions[o + 1]
+      const botX = positions[o + 2]
+      const botY = positions[o + 3]
+      expect(topX).toBeCloseTo(s.x + s.nx * halfW)
+      expect(topY).toBeCloseTo(s.y + s.ny * halfW)
+      expect(botX).toBeCloseTo(s.x - s.nx * halfW)
+      expect(botY).toBeCloseTo(s.y - s.ny * halfW)
+      const dx = topX - botX
+      const dy = topY - botY
+      expect(Math.sqrt(dx * dx + dy * dy)).toBeCloseTo(1.5)
+    }
+  })
+
+  it('CR-1: GPU position buffer is flagged dirty (update() called) on every frame', () => {
+    // Without the explicit getBuffer('aPosition').update() call, the
+    // mutated positions never reach the GPU and the mesh would freeze at
+    // its initial (zero-filled) geometry. A refactor that drops that call
+    // would silently break edge animation; this test catches it.
+    const layer = new EdgesLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1', 0, 0)],
+      ['a2', makeAgent('a2', 100, 100)],
+    ])
+    const edges = [makeEdge('e1', 'a1', 'a2')]
+
+    layer.update(edges, [], agents, new Map(), 0)
+    const entry = layer.getEntry('e1')!
+    const buffer = entry.mesh.geometry.getBuffer('aPosition') as unknown as { _updates: number }
+    expect(buffer._updates).toBeGreaterThanOrEqual(1)
+    const updatesAfterFrame1 = buffer._updates
+
+    // Frame 2: same edge, different time. Even if endpoints did not move,
+    // the layer must re-flag the buffer because positions are recomputed
+    // every frame from the polyline samples.
+    layer.update(edges, [], agents, new Map(), 0.016)
+    expect(buffer._updates).toBeGreaterThan(updatesAfterFrame1)
+  })
+
+  // ─── CR-3: leak prevention with destroy() spy ───────────────────────────
+
+  it('CR-3: stale entries are destroyed (mesh.destroy spied) and dropped from the map', () => {
+    // Strengthens the existing "destroys mesh entries" test by:
+    //   (1) running 3 stable frames (so the buggy "hide only" code would
+    //       have grown the entries Map across frames),
+    //   (2) feeding zero edges in the final frame (full sweep),
+    //   (3) spying on Mesh.destroy to confirm the GPU teardown runs, not
+    //       just a Map.delete.
+    const layer = new EdgesLayer()
+    const agents = new Map<string, Agent>([
+      ['a1', makeAgent('a1', 0, 0)],
+      ['a2', makeAgent('a2', 100, 100)],
+      ['a3', makeAgent('a3', 200, 200)],
+      ['a4', makeAgent('a4', 300, 300)],
+      ['a5', makeAgent('a5', 400, 400)],
+      ['a6', makeAgent('a6', 500, 500)],
+    ])
+    const edges = [
+      makeEdge('e1', 'a1', 'a2'),
+      makeEdge('e2', 'a3', 'a4'),
+      makeEdge('e3', 'a5', 'a6'),
+      makeEdge('e4', 'a2', 'a4'),
+      makeEdge('e5', 'a3', 'a5'),
+    ]
+
+    // Three stable frames — entries should stabilise at 5.
+    layer.update(edges, [], agents, new Map(), 0)
+    layer.update(edges, [], agents, new Map(), 0.016)
+    layer.update(edges, [], agents, new Map(), 0.032)
+    expect(layer.entryCount).toBe(5)
+
+    // Spy on each entry's mesh.destroy to confirm cleanup runs.
+    const destroySpies = ['e1', 'e2', 'e3', 'e4', 'e5'].map(id => {
+      const entry = layer.getEntry(id)!
+      return vi.spyOn(entry.mesh, 'destroy')
+    })
+
+    // Frame 4: zero edges → full sweep.
+    layer.update([], [], agents, new Map(), 0.048)
+
+    expect(layer.entryCount).toBe(0)
+    for (const spy of destroySpies) {
+      expect(spy).toHaveBeenCalled()
+    }
+  })
 })

--- a/web/components/agent-visualizer/pixi/edges-layer.ts
+++ b/web/components/agent-visualizer/pixi/edges-layer.ts
@@ -16,7 +16,7 @@ import { BEAM, ANIM } from '@/lib/agent-types'
 import { COLORS } from '@/lib/colors'
 import { MIN_VISIBLE_OPACITY } from '@/lib/canvas-constants'
 import { getActiveEdgeIds } from '../canvas/draw-edges'
-import { BezierCache } from './bezier-cache'
+import { sharedBezierCache } from './bezier-cache'
 
 /** Persistent state for a single edge rope. */
 interface EdgeEntry {
@@ -68,10 +68,6 @@ export class EdgesLayer {
   /** Persistent rope entries keyed by edge id. */
   private entries = new Map<string, EdgeEntry>()
 
-  /** Shared bezier cache (same instance the particles layer would use,
-   *  but edges-layer owns its own to avoid coupling). */
-  private readonly bezierCache: BezierCache
-
   /** Tint values for tool vs parent-child edges, precomputed once. */
   private readonly toolTint: number
   private readonly parentChildTint: number
@@ -79,7 +75,6 @@ export class EdgesLayer {
   constructor() {
     this.container = new Container()
     this.container.label = 'edges'
-    this.bezierCache = new BezierCache()
     this.toolTint = parseHexColor(COLORS.tool)
     this.parentChildTint = parseHexColor(COLORS.holoBase)
   }
@@ -114,7 +109,7 @@ export class EdgesLayer {
           : null
       if (!target) continue
 
-      const polyline = this.bezierCache.get(edge, agents, toolCalls)
+      const polyline = sharedBezierCache.get(edge, agents, toolCalls)
       if (!polyline) continue
 
       aliveIds.add(edge.id)
@@ -187,12 +182,13 @@ export class EdgesLayer {
     // Prune bezier cache entries for edges that no longer exist in the
     // simulation. Use aliveIds (edges that resolved to valid endpoints
     // this frame) rather than all edge ids, mirroring particles-layer.
-    this.bezierCache.prune(aliveIds)
+    sharedBezierCache.prune(aliveIds)
   }
 
-  /** Release GPU resources and remove all display objects. */
+  /** Release GPU resources and remove all display objects.
+   *  The shared bezier cache is intentionally NOT cleared here — particles-layer
+   *  may still depend on it, and the singleton survives mount/remount cycles. */
   dispose(): void {
-    this.bezierCache.clear()
     for (const entry of this.entries.values()) {
       entry.rope.destroy()
     }

--- a/web/components/agent-visualizer/pixi/edges-layer.ts
+++ b/web/components/agent-visualizer/pixi/edges-layer.ts
@@ -1,16 +1,23 @@
 /**
- * Edge rendering layer — one MeshRope per edge, driven by precomputed
+ * Edge rendering layer — one custom strip Mesh per edge, driven by precomputed
  * polyline samples from BezierCache.
+ *
+ * Each mesh is a triangle strip whose vertices are placed ±beamWidth/2 along
+ * the curve normal at every sample point. This restores the per-edge-type
+ * width that the previous MeshRope path silently overrode (MeshRope's `width`
+ * option is geometry-only — Pixi v8's renderer ignores it once the mesh is
+ * batched, so all edges rendered at the texture's native height).
  *
  * Active edges (those with particles) get brighter tint + higher alpha;
  * idle edges are dimmer. A time-based pulse modulates active-edge alpha
- * to match the Canvas2D path's animation.
+ * to match the Canvas2D path's animation. All edges share a single 1×1
+ * white texture and tint per mesh — preserves Pixi's auto-batching.
  *
  * Follows the same pattern as ParticlesLayer: constructor creates a
  * Container, update() is called once per rAF tick, dispose() tears down.
  */
 
-import { Container, MeshRope, Point, Texture } from 'pixi.js'
+import { Container, Mesh, MeshGeometry, Texture } from 'pixi.js'
 import type { Agent, Edge, Particle, ToolCallNode } from '@/lib/agent-types'
 import { BEAM, ANIM } from '@/lib/agent-types'
 import { COLORS } from '@/lib/colors'
@@ -18,11 +25,17 @@ import { MIN_VISIBLE_OPACITY } from '@/lib/canvas-constants'
 import { getActiveEdgeIds } from '../canvas/draw-edges'
 import { sharedBezierCache } from './bezier-cache'
 
-/** Persistent state for a single edge rope. */
+/** Persistent state for a single edge mesh. */
 interface EdgeEntry {
-  rope: MeshRope
-  /** The point objects fed to MeshRope — mutated in-place each frame. */
-  points: Point[]
+  /** Strip mesh — two vertices per polyline sample (top/bottom of strip). */
+  mesh: Mesh<MeshGeometry>
+  /** Reference to the geometry's positions array — mutated in-place each frame. */
+  positions: Float32Array
+  /** Beam width this entry was built for. If the edge type changes, the
+   *  geometry is rebuilt to match. (In practice edge.type is immutable.) */
+  beamWidth: number
+  /** Number of samples (sample count along the polyline). */
+  sampleCount: number
   /** Edge id this entry is keyed to. */
   edgeId: string
 }
@@ -35,37 +48,94 @@ function parseHexColor(hex: string): number {
   return 0xffffff
 }
 
-/** Width of the rope texture in pixels. The texture is a 1-pixel-tall white
- *  strip — the rope's visual width is controlled by the texture height and
- *  the `width` option on MeshRope. */
-const ROPE_TEXTURE_SIZE = 4
-
-/** Lazily created 1×N white texture for MeshRope. */
+/** Lazily created 1×1 white texture shared by every edge mesh. The mesh's
+ *  geometry encodes width directly; the texture is just a colourable surface
+ *  for the strip. Sharing one texture across all meshes keeps batching viable. */
 let ropeTexture: Texture | null = null
 
 function getRopeTexture(): Texture {
   if (ropeTexture) return ropeTexture
   const canvas = document.createElement('canvas')
-  canvas.width = ROPE_TEXTURE_SIZE
-  canvas.height = ROPE_TEXTURE_SIZE
+  canvas.width = 1
+  canvas.height = 1
   const ctx = canvas.getContext('2d')
   if (ctx) {
     ctx.fillStyle = '#ffffff'
-    ctx.fillRect(0, 0, ROPE_TEXTURE_SIZE, ROPE_TEXTURE_SIZE)
+    ctx.fillRect(0, 0, 1, 1)
   }
   ropeTexture = Texture.from(canvas)
   return ropeTexture
 }
 
 /**
+ * Build the strip geometry for a polyline of length `sampleCount`. Positions
+ * are zero-initialised (the caller fills them on the same frame). Indices and
+ * UVs are static — they depend only on `sampleCount`, not the actual sample
+ * coordinates, so they're built once and never touched again.
+ *
+ * Layout: each sample contributes two vertices (top/bottom of the strip).
+ * Vertex order: [s0_top, s0_bot, s1_top, s1_bot, …]. Two triangles per quad.
+ */
+function buildStripGeometry(sampleCount: number): MeshGeometry {
+  const vertexCount = sampleCount * 2
+  const positions = new Float32Array(vertexCount * 2) // x, y per vertex
+  const uvs = new Float32Array(vertexCount * 2)
+  const quadCount = sampleCount - 1
+  const indices = new Uint32Array(quadCount * 6)
+
+  // UVs: u alternates 0/1 across the strip width, v progresses along its length.
+  // Texture is 1×1 so values are visually irrelevant, but Pixi requires the
+  // attribute to exist and be sized correctly.
+  for (let i = 0; i < sampleCount; i++) {
+    const v = i / Math.max(1, sampleCount - 1)
+    uvs[i * 4 + 0] = 0  // top u
+    uvs[i * 4 + 1] = v  // top v
+    uvs[i * 4 + 2] = 1  // bot u
+    uvs[i * 4 + 3] = v  // bot v
+  }
+
+  // Indices: quad i is samples[i] and samples[i+1].
+  // Vertex offsets: top[i] = 2i, bot[i] = 2i+1.
+  for (let i = 0; i < quadCount; i++) {
+    const t0 = i * 2
+    const b0 = i * 2 + 1
+    const t1 = i * 2 + 2
+    const b1 = i * 2 + 3
+    const o = i * 6
+    indices[o + 0] = t0
+    indices[o + 1] = b0
+    indices[o + 2] = t1
+    indices[o + 3] = b0
+    indices[o + 4] = b1
+    indices[o + 5] = t1
+  }
+
+  return new MeshGeometry({
+    positions,
+    uvs,
+    indices,
+    topology: 'triangle-list',
+  })
+}
+
+/** Destroy a mesh entry's GPU resources. The geometry is per-edge so we own
+ *  it and free its buffers; the texture is module-shared so we never free it. */
+function destroyEntryMesh(entry: EdgeEntry): void {
+  // Geometry first — destroyBuffers=true releases the underlying GPU buffers.
+  // Mesh.destroy() does not cascade into geometry, so this must be explicit.
+  entry.mesh.geometry.destroy(true)
+  entry.mesh.destroy({ children: true, texture: false })
+}
+
+/**
  * Manages the edge rendering layer. Owns a Container that the caller adds
  * to the Pixi stage. Call `update()` each frame with the current simulation
- * state to position and style ropes.
+ * state to position and style meshes.
  */
 export class EdgesLayer {
   readonly container: Container
 
-  /** Persistent rope entries keyed by edge id. */
+  /** Persistent mesh entries keyed by edge id. */
   private entries = new Map<string, EdgeEntry>()
 
   /** Tint values for tool vs parent-child edges, precomputed once. */
@@ -80,7 +150,7 @@ export class EdgesLayer {
   }
 
   /**
-   * Update all edge ropes for the current frame.
+   * Update all edge meshes for the current frame.
    * Called once per rAF tick from pixi-canvas.tsx.
    */
   update(
@@ -122,60 +192,64 @@ export class EdgesLayer {
       const tint = edge.type === 'tool' ? this.toolTint : this.parentChildTint
       const beamWidth = edge.type === 'tool' ? BEAM.tool.startW : BEAM.parentChild.startW
 
+      const samples = polyline.samples
+      const sampleCount = samples.length
+
       let entry = this.entries.get(edge.id)
 
-      if (!entry) {
-        // Create new rope for this edge
-        const points = polyline.samples.map(s => new Point(s.x, s.y))
-        const rope = new MeshRope({
-          texture: getRopeTexture(),
-          points,
-          width: beamWidth,
-        })
-        rope.label = `edge-${edge.id}`
-        this.container.addChild(rope)
-        entry = { rope, points, edgeId: edge.id }
-        this.entries.set(edge.id, entry)
-      } else {
-        // Update existing rope's point positions from the cache
-        const samples = polyline.samples
-        const pts = entry.points
-
-        // If sample count changed (shouldn't normally), rebuild points array
-        if (pts.length !== samples.length) {
-          const newPoints = samples.map(s => new Point(s.x, s.y))
-          // MeshRope in v8 uses RopeGeometry constructed from the points array.
-          // We must replace the rope since the geometry's vertex count is fixed.
-          entry.rope.destroy()
-          this.container.removeChild(entry.rope)
-          const rope = new MeshRope({
-            texture: getRopeTexture(),
-            points: newPoints,
-            width: beamWidth,
-          })
-          rope.label = `edge-${edge.id}`
-          this.container.addChild(rope)
-          entry.rope = rope
-          entry.points = newPoints
-        } else {
-          // Mutate point positions in-place — MeshRope auto-updates geometry
-          for (let i = 0; i < samples.length; i++) {
-            pts[i].x = samples[i].x
-            pts[i].y = samples[i].y
-          }
+      // Rebuild from scratch if missing OR if sample count / width changed
+      // (edge.type doesn't change in practice, but guard anyway).
+      if (!entry || entry.sampleCount !== sampleCount || entry.beamWidth !== beamWidth) {
+        if (entry) {
+          destroyEntryMesh(entry)
+          this.container.removeChild(entry.mesh)
         }
+        const geometry = buildStripGeometry(sampleCount)
+        const mesh = new Mesh<MeshGeometry>({
+          geometry,
+          texture: getRopeTexture(),
+        })
+        mesh.label = `edge-${edge.id}`
+        this.container.addChild(mesh)
+        entry = {
+          mesh,
+          positions: geometry.positions,
+          beamWidth,
+          sampleCount,
+          edgeId: edge.id,
+        }
+        this.entries.set(edge.id, entry)
       }
 
-      // Style the rope
-      entry.rope.tint = tint
-      entry.rope.alpha = baseAlpha * pulsing
-      entry.rope.visible = true
+      // Mutate vertex positions in place: ±halfWidth along the sample normal.
+      const positions = entry.positions
+      const halfW = beamWidth / 2
+      for (let i = 0; i < sampleCount; i++) {
+        const s = samples[i]
+        const ox = s.nx * halfW
+        const oy = s.ny * halfW
+        const o = i * 4 // 2 vertices per sample, 2 floats per vertex
+        positions[o + 0] = s.x + ox  // top.x
+        positions[o + 1] = s.y + oy  // top.y
+        positions[o + 2] = s.x - ox  // bottom.x
+        positions[o + 3] = s.y - oy  // bottom.y
+      }
+      // Flag the GPU buffer as dirty so the upload happens this frame.
+      entry.mesh.geometry.getBuffer('aPosition').update()
+
+      // Style the mesh
+      entry.mesh.tint = tint
+      entry.mesh.alpha = baseAlpha * pulsing
+      entry.mesh.visible = true
     }
 
-    // Hide ropes for edges no longer present
+    // Drop entries for edges no longer present. Keeping them around forever
+    // (the previous "hide" behaviour) leaked GPU buffers across long sessions.
     for (const [id, entry] of this.entries) {
       if (!aliveIds.has(id)) {
-        entry.rope.visible = false
+        destroyEntryMesh(entry)
+        this.container.removeChild(entry.mesh)
+        this.entries.delete(id)
       }
     }
 
@@ -190,7 +264,8 @@ export class EdgesLayer {
    *  may still depend on it, and the singleton survives mount/remount cycles. */
   dispose(): void {
     for (const entry of this.entries.values()) {
-      entry.rope.destroy()
+      // Geometry is per-edge so we own it; texture is shared so we don't.
+      destroyEntryMesh(entry)
     }
     this.entries.clear()
     this.container.destroy({ children: true })
@@ -201,7 +276,7 @@ export class EdgesLayer {
     return this.entries.size
   }
 
-  /** Retrieve a rope entry by edge id — useful for tests. */
+  /** Retrieve a mesh entry by edge id — useful for tests. */
   getEntry(edgeId: string): EdgeEntry | undefined {
     return this.entries.get(edgeId)
   }

--- a/web/components/agent-visualizer/pixi/edges-layer.ts
+++ b/web/components/agent-visualizer/pixi/edges-layer.ts
@@ -118,9 +118,13 @@ function buildStripGeometry(sampleCount: number): MeshGeometry {
   })
 }
 
-/** Destroy a mesh entry's GPU resources. The geometry is per-edge so we own
- *  it and free its buffers; the texture is module-shared so we never free it. */
-function destroyEntryMesh(entry: EdgeEntry): void {
+/** Canonical disposal path for an edge mesh entry. Removes from the parent
+ *  container BEFORE destroying — Pixi convention is remove-then-destroy so
+ *  the parent's child list never holds a reference to a destroyed object.
+ *  Geometry is per-edge so we own it and free its buffers; the texture is
+ *  module-shared so we never free it. */
+function destroyEntryMesh(parent: Container, entry: EdgeEntry): void {
+  parent.removeChild(entry.mesh)
   // Geometry first — destroyBuffers=true releases the underlying GPU buffers.
   // Mesh.destroy() does not cascade into geometry, so this must be explicit.
   entry.mesh.geometry.destroy(true)
@@ -201,8 +205,7 @@ export class EdgesLayer {
       // (edge.type doesn't change in practice, but guard anyway).
       if (!entry || entry.sampleCount !== sampleCount || entry.beamWidth !== beamWidth) {
         if (entry) {
-          destroyEntryMesh(entry)
-          this.container.removeChild(entry.mesh)
+          destroyEntryMesh(this.container, entry)
         }
         const geometry = buildStripGeometry(sampleCount)
         const mesh = new Mesh<MeshGeometry>({
@@ -247,8 +250,7 @@ export class EdgesLayer {
     // (the previous "hide" behaviour) leaked GPU buffers across long sessions.
     for (const [id, entry] of this.entries) {
       if (!aliveIds.has(id)) {
-        destroyEntryMesh(entry)
-        this.container.removeChild(entry.mesh)
+        destroyEntryMesh(this.container, entry)
         this.entries.delete(id)
       }
     }
@@ -264,11 +266,15 @@ export class EdgesLayer {
    *  may still depend on it, and the singleton survives mount/remount cycles. */
   dispose(): void {
     for (const entry of this.entries.values()) {
-      // Geometry is per-edge so we own it; texture is shared so we don't.
-      destroyEntryMesh(entry)
+      // Each entry is removed from the container and destroyed (geometry +
+      // mesh). After this loop the container is empty, so destroying it does
+      // not need to cascade into children — `destroy({children:true})` would
+      // otherwise re-destroy the same meshes (currently safe only because
+      // Pixi v8 destroy() is idempotent — fragile to rely on).
+      destroyEntryMesh(this.container, entry)
     }
     this.entries.clear()
-    this.container.destroy({ children: true })
+    this.container.destroy()
   }
 
   /** Number of active edge entries — useful for tests. */

--- a/web/components/agent-visualizer/pixi/particles-layer.ts
+++ b/web/components/agent-visualizer/pixi/particles-layer.ts
@@ -82,10 +82,11 @@ export class ParticlesLayer {
     const edgeMap = new Map<string, Edge>()
     for (const e of edges) edgeMap.set(e.id, e)
 
-    // Prune bezier cache of edges that no longer exist
-    const activeEdgeIds = new Set<string>()
-    for (const p of particles) activeEdgeIds.add(p.edgeId)
-    sharedBezierCache.prune(activeEdgeIds)
+    // Bezier-cache pruning is owned exclusively by EdgesLayer, which sees the
+    // full set of alive edges every frame. Pruning here would evict polylines
+    // for idle edges (those without active particles) that EdgesLayer just
+    // populated, undoing the IR-1 caching win. ParticlesLayer is a pure
+    // consumer — it only `get()`s.
 
     for (const particle of particles) {
       const edge = edgeMap.get(particle.edgeId)

--- a/web/components/agent-visualizer/pixi/particles-layer.ts
+++ b/web/components/agent-visualizer/pixi/particles-layer.ts
@@ -17,6 +17,20 @@ import { getGlowTexture, getCircleTexture } from './pixi-app'
 import type { BezierSample } from './bezier-cache'
 import { sharedBezierCache, samplePolyline } from './bezier-cache'
 
+/** Pre-parsed tint for the highlight (center bright spot) — same value
+ *  for every particle, parsed once at module load instead of per-particle
+ *  per-frame. */
+const HOLO_HOT_TINT = parseHexColorAtModuleScope(COLORS.holoHot)
+
+/** Module-scope hex parser used only for HOLO_HOT_TINT. The class instance
+ *  has its own (identical) implementation that doubles as the cache writer. */
+function parseHexColorAtModuleScope(hex: string): number {
+  if (hex.startsWith('#')) {
+    return parseInt(hex.slice(1, 7), 16)
+  }
+  return 0xffffff
+}
+
 /** Pool of sprites to avoid allocation churn. Each frame we show/hide as needed. */
 interface SpriteEntry {
   sprite: Sprite
@@ -80,6 +94,14 @@ export class ParticlesLayer {
       const polyline = sharedBezierCache.get(edge, agents, toolCalls)
       if (!polyline) continue
 
+      // IR-4: cache the parsed numeric tint on the particle itself. The hex
+      // string is immutable for the particle's lifetime, so this is a one-time
+      // parse per particle (instead of 4+ parses per particle per frame).
+      if (particle._tint === undefined) {
+        particle._tint = this.parseColor(particle.color)
+      }
+      const particleTint = particle._tint
+
       const t = particle.progress
       const isReturn = particle.type === 'return' || particle.type === 'tool_return'
 
@@ -115,7 +137,7 @@ export class ParticlesLayer {
         // Scale relative to the 8px radius circle texture
         const s = scale / 8
         sprite.scale.set(s)
-        sprite.tint = this.parseColor(particle.color)
+        sprite.tint = particleTint
         sprite.alpha = alpha
         sprite.blendMode = 'normal'
       }
@@ -136,7 +158,7 @@ export class ParticlesLayer {
       core.y = py
       core.anchor.set(0.5)
       core.scale.set(particle.size / 8)
-      core.tint = this.parseColor(particle.color)
+      core.tint = particleTint
       core.alpha = 1
       core.blendMode = 'normal'
 
@@ -146,7 +168,7 @@ export class ParticlesLayer {
       highlight.y = py
       highlight.anchor.set(0.5)
       highlight.scale.set((particle.size * PARTICLE_DRAW.coreHighlightScale) / 8)
-      highlight.tint = this.parseColor(COLORS.holoHot)
+      highlight.tint = HOLO_HOT_TINT
       highlight.alpha = 0.5 // matches the '80' hex alpha from Canvas2D path
       highlight.blendMode = 'normal'
     }

--- a/web/components/agent-visualizer/pixi/particles-layer.ts
+++ b/web/components/agent-visualizer/pixi/particles-layer.ts
@@ -14,7 +14,8 @@ import { BEAM, FX } from '@/lib/agent-types'
 import { COLORS } from '@/lib/colors'
 import { PARTICLE_DRAW } from '@/lib/canvas-constants'
 import { getGlowTexture, getCircleTexture } from './pixi-app'
-import { BezierCache, samplePolyline } from './bezier-cache'
+import type { BezierSample } from './bezier-cache'
+import { sharedBezierCache, samplePolyline } from './bezier-cache'
 
 /** Pool of sprites to avoid allocation churn. Each frame we show/hide as needed. */
 interface SpriteEntry {
@@ -31,17 +32,19 @@ export class ParticlesLayer {
   readonly container: Container
   private pool: SpriteEntry[] = []
   private poolIndex = 0
-  private readonly bezierCache: BezierCache
   private readonly circleTexture: Texture
   private readonly glowRadius = PARTICLE_DRAW.glowRadius
 
   /** Color object reused every frame to avoid allocation. */
   private readonly tmpColor = new Color()
 
+  /** Scratch BezierSample reused across all samplePolyline() calls each
+   *  frame. Each call's result is read before the next call overwrites it. */
+  private readonly tmpSample: BezierSample = { x: 0, y: 0, nx: 0, ny: 0 }
+
   constructor() {
     this.container = new Container()
     this.container.label = 'particles'
-    this.bezierCache = new BezierCache()
     // Pre-create a circle texture at a reasonable base size.
     // Sprites scale from this.
     this.circleTexture = getCircleTexture(8)
@@ -68,13 +71,13 @@ export class ParticlesLayer {
     // Prune bezier cache of edges that no longer exist
     const activeEdgeIds = new Set<string>()
     for (const p of particles) activeEdgeIds.add(p.edgeId)
-    this.bezierCache.prune(activeEdgeIds)
+    sharedBezierCache.prune(activeEdgeIds)
 
     for (const particle of particles) {
       const edge = edgeMap.get(particle.edgeId)
       if (!edge) continue
 
-      const polyline = this.bezierCache.get(edge, agents, toolCalls)
+      const polyline = sharedBezierCache.get(edge, agents, toolCalls)
       if (!polyline) continue
 
       const t = particle.progress
@@ -86,7 +89,7 @@ export class ParticlesLayer {
       // Current position (with wobble)
       const wobbleAmt = Math.sin(t * BEAM.wobble.freq + time * BEAM.wobble.timeFreq + phase) *
         BEAM.wobble.amp * Math.sin(t * Math.PI)
-      const baseSample = samplePolyline(polyline, t)
+      const baseSample = samplePolyline(polyline, t, this.tmpSample)
       const px = baseSample.x + baseSample.nx * wobbleAmt
       const py = baseSample.y + baseSample.ny * wobbleAmt
 
@@ -98,7 +101,7 @@ export class ParticlesLayer {
           : Math.max(0, t - offset)
         const wob = Math.sin(tt * BEAM.wobble.freq + time * BEAM.wobble.timeFreq + phase) *
           BEAM.wobble.amp * Math.sin(tt * Math.PI)
-        const sample = samplePolyline(polyline, tt)
+        const sample = samplePolyline(polyline, tt, this.tmpSample)
         const tx = sample.x + sample.nx * wob
         const ty = sample.y + sample.ny * wob
 
@@ -152,9 +155,10 @@ export class ParticlesLayer {
     this.hideUnused()
   }
 
-  /** Release GPU resources. */
+  /** Release GPU resources.
+   *  The shared bezier cache is intentionally NOT cleared here — edges-layer
+   *  may still depend on it, and the singleton survives mount/remount cycles. */
   destroy(): void {
-    this.bezierCache.clear()
     for (const entry of this.pool) {
       entry.sprite.destroy()
     }

--- a/web/components/agent-visualizer/pixi/pixi-canvas.tsx
+++ b/web/components/agent-visualizer/pixi/pixi-canvas.tsx
@@ -16,7 +16,7 @@
  * Bloom post-processing is applied per-viewport as a stage-level filter.
  */
 
-import { useRef, useEffect, useState, useMemo, useId } from 'react'
+import { useRef, useEffect, useState, useMemo, useCallback, useId } from 'react'
 import { Container, EventBoundary } from 'pixi.js'
 import type { SimulationState } from '@/hooks/simulation/types'
 import { useCanvasCamera } from '@/hooks/use-canvas-camera'
@@ -166,6 +166,11 @@ export function PixiCanvas({
   const simTimeRef = useRef(0)
 
   // ─── DrawProps ref for camera + interaction hooks ───────────────────────
+  // IR-15: every dynamic value pixiDraw needs lives in this ref so the
+  // draw closure has zero React-prop captures and can be wrapped in a
+  // useCallback with empty deps. Without this, pixiDraw was reallocated
+  // on every parent render — and its identity flowed into the manager's
+  // registerRender effect, churning the registration pointer.
   const sim = simulationRef.current
   const drawPropsRef = useRef({
     agents: sim.agents,
@@ -173,6 +178,12 @@ export function PixiCanvas({
     discoveries: sim.discoveries,
     dimensions,
     selectedAgentId,
+    selectedToolCallId,
+    selectedDiscoveryId,
+    hoveredAgentId,
+    showStats,
+    showHexGrid,
+    effects,
     pauseAutoFit,
     isDragging: false,
     onAgentClick,
@@ -185,6 +196,12 @@ export function PixiCanvas({
 
   // Sync React props into drawPropsRef every render
   drawPropsRef.current.selectedAgentId = selectedAgentId
+  drawPropsRef.current.selectedToolCallId = selectedToolCallId
+  drawPropsRef.current.selectedDiscoveryId = selectedDiscoveryId
+  drawPropsRef.current.hoveredAgentId = hoveredAgentId
+  drawPropsRef.current.showStats = showStats
+  drawPropsRef.current.showHexGrid = showHexGrid
+  drawPropsRef.current.effects = effects
   drawPropsRef.current.pauseAutoFit = pauseAutoFit
   drawPropsRef.current.dimensions = dimensions
   drawPropsRef.current.onAgentClick = onAgentClick
@@ -230,11 +247,14 @@ export function PixiCanvas({
   updateDragLerpRef.current = updateDragLerp
 
   // ─── Draw callback (registered with shared render loop) ─────────────
-  // The render-loop registration reads through drawRef.current, so identity
-  // stability isn't observed downstream — useCallback would be pure overhead.
-  const drawRef = useRef<(timestamp: number) => void>(() => {})
-
-  const pixiDraw = (timestamp: number) => {
+  // IR-15: Every dynamic value flows through drawPropsRef so this closure
+  // has zero React-prop captures. Wrapping in useCallback with empty deps
+  // means the function identity stays stable for the component's lifetime,
+  // which lets the registerRender effect skip re-registering on each parent
+  // render. The eslint-disable is intentional — we are deliberately reading
+  // refs and stable handles inside a deps:[] callback.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const pixiDraw = useCallback((timestamp: number) => {
     if (!readyRef.current) return
 
     // Skip rendering when the canvas is off-screen (IntersectionObserver).
@@ -267,16 +287,16 @@ export function PixiCanvas({
     // Apply camera transform to the world container
     applyCameraTransform(world, transformRef.current)
 
-    // Update layers
+    // Update layers — every dynamic input is read through `p`.
     backgroundLayerRef.current?.update(
       p.dimensions.width,
       p.dimensions.height,
       transformRef.current,
       dt,
       timeRef.current,
-      showHexGrid,
+      p.showHexGrid,
       undefined,
-      effects.backgroundParticles,
+      p.effects.backgroundParticles,
     )
 
     edgesLayerRef.current?.update(
@@ -290,35 +310,35 @@ export function PixiCanvas({
     toolCallsLayerRef.current?.update(
       s.toolCalls,
       timeRef.current,
-      selectedToolCallId,
+      p.selectedToolCallId,
     )
 
     discoveriesLayerRef.current?.update(
       s.discoveries,
       s.agents,
-      selectedDiscoveryId,
+      p.selectedDiscoveryId,
     )
 
     agentsLayerRef.current?.update(
       s.agents,
-      selectedAgentId,
-      hoveredAgentId,
-      showStats,
+      p.selectedAgentId,
+      p.hoveredAgentId,
+      p.showStats,
       timeRef.current,
     )
 
     // Disabled-effect layers skip their update entirely and hide their
     // container — saves both the JS update cost and the GPU draw call.
     if (bubblesLayerRef.current) {
-      bubblesLayerRef.current.container.visible = effects.bubbles
-      if (effects.bubbles) {
+      bubblesLayerRef.current.container.visible = p.effects.bubbles
+      if (p.effects.bubbles) {
         bubblesLayerRef.current.update(s.agents, timeRef.current)
       }
     }
 
     if (particlesLayerRef.current) {
-      particlesLayerRef.current.container.visible = effects.particles
-      if (effects.particles) {
+      particlesLayerRef.current.container.visible = p.effects.particles
+      if (p.effects.particles) {
         particlesLayerRef.current.update(
           s.particles,
           s.edges,
@@ -331,15 +351,12 @@ export function PixiCanvas({
 
     // Render this viewport via the shared renderer and blit to the visible canvas
     renderViewport(viewportId)
-  }
-
-  drawRef.current = pixiDraw
+  }, [viewportId, simulationRef])
 
   // Register with the shared render loop.
   useEffect(() => {
-    const callback = (timestamp: number) => drawRef.current(timestamp)
-    return manager.registerRender(callback)
-  }, [manager])
+    return manager.registerRender(pixiDraw)
+  }, [manager, pixiDraw])
 
   // ─── Bootstrap (shared renderer + scene graph) ─────────────────────────
 

--- a/web/components/agent-visualizer/pixi/pixi-canvas.tsx
+++ b/web/components/agent-visualizer/pixi/pixi-canvas.tsx
@@ -248,11 +248,13 @@ export function PixiCanvas({
 
   // ─── Draw callback (registered with shared render loop) ─────────────
   // IR-15: Every dynamic value flows through drawPropsRef so this closure
-  // has zero React-prop captures. Wrapping in useCallback with empty deps
-  // means the function identity stays stable for the component's lifetime,
-  // which lets the registerRender effect skip re-registering on each parent
-  // render. The eslint-disable is intentional — we are deliberately reading
-  // refs and stable handles inside a deps:[] callback.
+  // has zero React-prop captures. Wrapping in useCallback with deps that
+  // are all lifetime-stable refs (viewportId from useId, simulationRef from
+  // useRef) means the function identity stays stable for the component's
+  // lifetime, which lets the registerRender effect skip re-registering on
+  // each parent render. The eslint-disable is intentional — we are
+  // deliberately reading refs and stable handles inside the callback
+  // without listing them as deps.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const pixiDraw = useCallback((timestamp: number) => {
     if (!readyRef.current) return

--- a/web/components/agent-visualizer/pixi/tool-calls-layer.test.ts
+++ b/web/components/agent-visualizer/pixi/tool-calls-layer.test.ts
@@ -50,11 +50,18 @@ vi.mock('pixi.js', () => {
     label = ''
     visible = true
     _cleared = false
-    clear() { this._cleared = true; return this }
-    roundRect() { return this }
+    // Per-instance call counters (added for IR-6 background-rebuild gating
+    // assertions). Existing tests rely on `_cleared` only and are unaffected
+    // by the additive counters.
+    _clearCount = 0
+    _roundRectCount = 0
+    _fillCount = 0
+    _strokeCount = 0
+    clear() { this._cleared = true; this._clearCount++; return this }
+    roundRect() { this._roundRectCount++; return this }
     rect() { return this }
-    fill(_opts: unknown) { return this }
-    stroke(_opts: unknown) { return this }
+    fill(_opts: unknown) { this._fillCount++; return this }
+    stroke(_opts: unknown) { this._strokeCount++; return this }
     destroy() { /* no-op */ }
   }
 
@@ -201,5 +208,83 @@ describe('ToolCallsLayer', () => {
     expect(layer.getEntry('t1')!.container.visible).toBe(true)
     expect(layer.getEntry('t2')).toBeUndefined()
     expect(layer.entryCount).toBe(1)
+  })
+
+  // ─── CR-3: leak prevention with destroy() spy across multi-frame window ──
+
+  it('CR-3: 5 tool-calls stable for 3 frames then absent → entries destroyed and dropped', () => {
+    // Strengthens the simple two-frame transition above by:
+    //   (1) stabilising entries across 3 frames so the buggy "hide only"
+    //       path would have produced a monotonically growing map,
+    //   (2) feeding zero tool calls in the final frame (full sweep),
+    //   (3) spying on container.destroy to verify GPU teardown actually
+    //       runs, not just a Map.delete.
+    const layer = new ToolCallsLayer()
+    const toolCalls = new Map<string, ToolCallNode>([
+      ['t1', makeToolCall('t1')],
+      ['t2', makeToolCall('t2')],
+      ['t3', makeToolCall('t3')],
+      ['t4', makeToolCall('t4')],
+      ['t5', makeToolCall('t5')],
+    ])
+
+    layer.update(toolCalls, 0)
+    layer.update(toolCalls, 0.016)
+    layer.update(toolCalls, 0.032)
+    expect(layer.entryCount).toBe(5)
+
+    const destroySpies = ['t1', 't2', 't3', 't4', 't5'].map(id => {
+      const entry = layer.getEntry(id)!
+      return vi.spyOn(entry.container, 'destroy')
+    })
+
+    layer.update(new Map(), 0.048)
+    expect(layer.entryCount).toBe(0)
+    for (const spy of destroySpies) {
+      expect(spy).toHaveBeenCalled()
+    }
+  })
+
+  // ─── IR-6: background rebuild gating ─────────────────────────────────────
+  // The background Graphics is regenerated only when its inputs change.
+  // The pulse value continuously varies but is quantized to 1/20 buckets,
+  // so a 30-frame stable session produces only a handful of distinct keys.
+  // Pre-fix (no key gating) every frame would clear+roundRect+fill+stroke
+  // the background; this test pins the post-fix bound at "well below 30".
+
+  it('IR-6: background Graphics rebuild count stays below frame count for stable tool call', () => {
+    const layer = new ToolCallsLayer()
+    const tool = makeToolCall('t1', { state: 'running' })
+    const toolCalls = new Map<string, ToolCallNode>([['t1', tool]])
+
+    // First update creates the entry; capture the per-instance counters.
+    layer.update(toolCalls, 0)
+    const entry = layer.getEntry('t1')!
+    const bg = entry.background as unknown as {
+      _clearCount: number
+      _roundRectCount: number
+      _fillCount: number
+      _strokeCount: number
+    }
+    const FRAMES = 30
+    const initialClears = bg._clearCount
+
+    // Run 30 stable frames at 60fps. The pulse varies (sin(time*4)) but
+    // pulseBucket = round(pulse*20) lives in a small set across this
+    // window — empirically 5-9 distinct buckets — so the rebuild count
+    // must stay well below 30.
+    for (let frame = 1; frame <= FRAMES; frame++) {
+      layer.update(toolCalls, frame * 0.016)
+    }
+
+    const clearsDuringWindow = bg._clearCount - initialClears
+    // Post-fix: gated rebuilds. Pre-fix would have rebuilt every frame.
+    // Allow up to half the frame count as the safety margin (in practice
+    // it's 5-9). Anything close to 30 means the gate regressed.
+    expect(clearsDuringWindow).toBeLessThan(FRAMES / 2)
+    // The four chained calls move together.
+    expect(bg._roundRectCount).toBeLessThanOrEqual(bg._clearCount)
+    expect(bg._fillCount).toBeLessThanOrEqual(bg._clearCount)
+    expect(bg._strokeCount).toBeLessThanOrEqual(bg._clearCount)
   })
 })

--- a/web/components/agent-visualizer/pixi/tool-calls-layer.test.ts
+++ b/web/components/agent-visualizer/pixi/tool-calls-layer.test.ts
@@ -179,7 +179,10 @@ describe('ToolCallsLayer', () => {
     expect(layer.entryCount).toBe(0)
   })
 
-  it('tool calls that disappear between frames are hidden', () => {
+  it('destroys entries for tool calls that disappear between frames', () => {
+    // Stale-id sweep (CR-3): tool-call entries are destroyed when their id
+    // no longer appears in the input. Previously entries were merely hidden,
+    // accumulating monotonically over long sessions.
     const layer = new ToolCallsLayer()
 
     const toolCalls1 = new Map<string, ToolCallNode>([
@@ -189,12 +192,14 @@ describe('ToolCallsLayer', () => {
     layer.update(toolCalls1, 0)
     expect(layer.getEntry('t1')!.container.visible).toBe(true)
     expect(layer.getEntry('t2')!.container.visible).toBe(true)
+    expect(layer.entryCount).toBe(2)
 
     const toolCalls2 = new Map<string, ToolCallNode>([
       ['t1', makeToolCall('t1')],
     ])
     layer.update(toolCalls2, 1)
     expect(layer.getEntry('t1')!.container.visible).toBe(true)
-    expect(layer.getEntry('t2')!.container.visible).toBe(false)
+    expect(layer.getEntry('t2')).toBeUndefined()
+    expect(layer.entryCount).toBe(1)
   })
 })

--- a/web/components/agent-visualizer/pixi/tool-calls-layer.ts
+++ b/web/components/agent-visualizer/pixi/tool-calls-layer.ts
@@ -40,6 +40,8 @@ interface ToolCallEntry {
   lastSecondaryText: string
   /** Last-rendered secondary color. */
   lastSecondaryColor: string
+  /** Cache key for the background Graphics commands. (IR-6) */
+  lastBgKey: string
   /** Tool call id. */
   toolCallId: string
 }
@@ -120,22 +122,32 @@ export class ToolCallsLayer {
       entry.container.visible = tool.opacity > 0.01
 
       // ── Background ─────────────────────────────────────────────────
-      entry.background.clear()
-      entry.background.roundRect(-cardW / 2, -cardH / 2, cardW, cardH, TOOL_DRAW.borderRadius)
+      // IR-6: gate the Graphics rebuild on a key over every input that
+      // affects the rendered shape. `pulse` varies continuously, so we
+      // quantize it to 1/20 increments — the human eye can't distinguish
+      // sub-bucket differences and this collapses 60Hz fluctuation into
+      // ~5 distinct keys per second.
+      const pulseBucket = Math.round(pulse * 20)
+      const bgKey = `${cardW}|${cardH}|${tool.state}|${isSelected}|${isError}|${pulseBucket}`
+      if (bgKey !== entry.lastBgKey) {
+        entry.background.clear()
+        entry.background.roundRect(-cardW / 2, -cardH / 2, cardW, cardH, TOOL_DRAW.borderRadius)
 
-      if (isError) {
-        entry.background.fill({ color: 0x280a0f, alpha: 0.8 * pulse })
-        entry.background.stroke({ width: 2, color: TINT_ERROR, alpha: 0.56 })
-      } else if (isSelected) {
-        entry.background.fill({ color: TINT_HOLO, alpha: 0.15 * pulse })
-        entry.background.stroke({ width: 1.5, color: TINT_HOLO, alpha: 0.67 })
-      } else {
-        entry.background.fill({ color: 0x0a0f1e, alpha: 0.7 * pulse })
-        entry.background.stroke({
-          width: 1,
-          color: isRunning ? TINT_TOOL : TINT_RETURN,
-          alpha: isRunning ? 0.375 : 0.25,
-        })
+        if (isError) {
+          entry.background.fill({ color: 0x280a0f, alpha: 0.8 * pulse })
+          entry.background.stroke({ width: 2, color: TINT_ERROR, alpha: 0.56 })
+        } else if (isSelected) {
+          entry.background.fill({ color: TINT_HOLO, alpha: 0.15 * pulse })
+          entry.background.stroke({ width: 1.5, color: TINT_HOLO, alpha: 0.67 })
+        } else {
+          entry.background.fill({ color: 0x0a0f1e, alpha: 0.7 * pulse })
+          entry.background.stroke({
+            width: 1,
+            color: isRunning ? TINT_TOOL : TINT_RETURN,
+            alpha: isRunning ? 0.375 : 0.25,
+          })
+        }
+        entry.lastBgKey = bgKey
       }
 
       // ── Selection tint ─────────────────────────────────────────────
@@ -276,6 +288,7 @@ export class ToolCallsLayer {
       lastLabelColor: '',
       lastSecondaryText: '',
       lastSecondaryColor: '',
+      lastBgKey: '',
       toolCallId,
     }
   }

--- a/web/components/agent-visualizer/pixi/tool-calls-layer.ts
+++ b/web/components/agent-visualizer/pixi/tool-calls-layer.ts
@@ -213,10 +213,14 @@ export class ToolCallsLayer {
       }
     }
 
-    // Hide entries for tool calls that no longer exist
+    // Drop entries for tool calls that no longer exist this frame. The
+    // simulation already enforces fade timing (animate.ts evicts faded
+    // tool calls only after opacity reaches 0), so layers can mirror its
+    // decisions without a grace period.
     for (const [id, entry] of this.entries) {
       if (!aliveIds.has(id)) {
-        entry.container.visible = false
+        entry.container.destroy({ children: true })
+        this.entries.delete(id)
       }
     }
   }

--- a/web/lib/agent-types.ts
+++ b/web/lib/agent-types.ts
@@ -142,6 +142,10 @@ export interface Particle {
   size: number
   trailLength: number
   label?: string        // what's flowing (e.g., "auth.ts 142 lines")
+  /** Cached numeric tint of `color`, populated lazily by the Pixi
+   *  renderer's particle layer. Avoids re-parsing the hex string on every
+   *  frame for every particle (4+ uses per particle per frame). */
+  _tint?: number
 }
 
 export interface SimulationEvent {


### PR DESCRIPTION
Closes #71. WG-1 of 5 from the 2026-05-03 perf review of `main`. All 11 issue findings (CR-1, CR-2, CR-3, IR-1..IR-7, IR-15) plus MR-2 in a single PR. Scope is contained to `web/components/agent-visualizer/pixi/*` plus a one-line `_tint?: number` cache field on `Particle` in `web/lib/agent-types.ts`. Independent of WG-2 (Canvas2D), WG-3 (React shell), WG-4 (relay), WG-5 (extension JSONL).

## Summary

- **CR-1**: `MeshRope` was silently overriding the authored beam width on every WebGL frame (Pixi 8.18.1's MeshRope.update sets `geometry._width = texture.height` per frame, making `BEAM.tool.startW` and `BEAM.parentChild.startW` dead constants — all beams rendered at the rope-texture's 4px half-width). Replaced MeshRope with a custom strip `Mesh` whose vertex offsets encode width directly (±beamWidth/2 along the cached polyline normals). Shared 1×1 white texture preserves auto-batching candidates.
- **CR-2**: Stats overlay glyph churn — `agent.timeAlive.toFixed(1)` ticks every ~100 ms and was destroying + reallocating a Sprite plus a fresh atlas glyph every change (~9000 unique entries per 90s window, triggering full LRU sweeps). Split the overlay into a stable label sprite (`"N tools · "`, re-renders only on `agent.toolCalls` change) and a 1Hz value sprite (`"Ms"` keyed on `Math.floor(timeAlive)`).
- **CR-3**: Layer entry maps never `.delete()`d — only hid stale entries. Sub-agents and tool calls fade out and the simulation correctly removes them, but layers leaked their containers forever (proportional GPU memory growth, scene-graph traversal walks zombie containers). Added stale-id sweep in agents/tool-calls/edges/discoveries layers (bubbles uses a free-list pool — left alone). Main agents persist by design and so do their entries.
- **IR-1**: `BezierCache` was duplicated in EdgesLayer and ParticlesLayer — same edges sampled twice per frame. Module-scope `sharedBezierCache` singleton; EdgesLayer is the authoritative pruner.
- **IR-2**: `samplePolyline` allocated `{x, y, nx, ny}` per call (~18,000 allocs/sec). Added scratch out-param signature; ParticlesLayer reuses a single `tmpSample` across both call sites in the trail loop.
- **IR-3**: Bubble line-wrapping rebuilt every frame. Mirrored the Canvas2D `_cachedWrappedLines` pattern on the `MessageBubble` data object.
- **IR-4**: `parseColor(particle.color)` ran ~9× per particle per frame; particle color is stable per-particle. Cache `_tint` lazily on the particle.
- **IR-5**: Discovery connection lines did `moveTo`+`lineTo`+`stroke()` per discovery (O(n) draw calls). Bucket by quantized alpha; one stroke per bucket.
- **IR-6**: Bubble / tool-call / discovery card backgrounds rebuilt every frame even when geometry/color stable. Added `lastBgKey` sibling to existing `lastContentKey` invalidation pattern (×20 quantization on the pulse term to avoid continuous-sine churn).
- **IR-7**: Hex grid allocated a fresh `Map<number, number[]>` plus bucket arrays per frame. Direct port of Canvas2D's module-level `HEX_BUCKETS` pattern with `arr.length = 0` reset.
- **IR-15**: `pixiDraw` closure allocated per render (~4Hz UI cadence + drag/resize). Extended `drawPropsRef` with all previously-captured dynamic values; wrapped in `useCallback` with stable refs as deps.
- **MR-2**: Active-agent glow tint was re-parsed every frame even when stable. Cache `lastGlowColor`.

## Verification

- `cd web && pnpm typecheck` — exit 0
- `cd web && pnpm test --run` — 181 tests pass (160 existing + 21 new regression tests pinning each finding)
- `cd web && pnpm build` — clean Next.js build
- Lead-code-reviewer: A+ on pass 2 of 3 (pass 1 caught a bezier-cache prune contract issue + 3 lifecycle nits, all addressed in 2c0ebb8)

## Test plan

- [x] CR-1: vertex-offset width assertion (parent-child halfW=1.5, tool halfW=0.75) at 3 sample indices each + Euclidean width check
- [x] CR-1: GPU buffer dirty-flag verified per frame (`getBuffer('aPosition').update()` invocation count ≥1 per update)
- [x] CR-2: 100-frame, 10Hz timeAlive simulation caps glyph requests at ≤11 for value sprite, ≤1 for label sprite (was ~100 pre-fix)
- [x] CR-3: leak-prevention test on each of 4 affected layers — feed N entities → feed 0 → assert `entries.size === 0` and destroy was called
- [x] IR-1: shared-singleton + cross-instantiation cache survival
- [x] IR-2: 1000-iteration `Object.is` reference-stability check on scratch out-param
- [x] IR-3: wrap-cache hit assertion (cache field stable across 10 frames)
- [x] IR-5: alpha-bucket count test (10 discoveries → 3 distinct alpha buckets → exactly 3 stroke calls)
- [x] IR-6: rebuild-count gating across bubbles/tool-calls/discoveries (clear+roundRect+fill+stroke calls bounded well below frame count)
- [x] IR-7: zero-allocation hex grid (Map constructor proxy confirms no per-frame Map construction during draw)
- [x] MR-2: parseColor called exactly once for stable active-agent color across 30 frames
- [ ] Bench harness (A-base vs C-pr1) — **blocked by infrastructure**: `baseline-tree/` and `pr1-tree/` sibling worktrees not provisioned at `/home/claudette/multi-agent-flow/`. Quantitative perf delta gates (p95 ≥25%, GC ≥50%, atlas plateau, heap stable) require manual ops setup. The 21 new unit tests pin the perf invariants directly so regressions cannot land silently.
- [ ] Manual visual diff Pixi vs Canvas2D — beams should taper to match Canvas2D (CR-1 acceptance)
- [ ] 5-min live sim — confirm scene-graph child count plateaus rather than growing monotonically (CR-3 acceptance)
- [ ] Per-effect toggle smoke (no visual regressions across showHexGrid / effects.bubbles / effects.particles / effects.bloom / effects.backgroundParticles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)