### PR TITLE
feat(canvas2d): default orchestrator label to "Orchestrator", allow rename via title bar

### DIFF
--- a/web/components/agent-visualizer/canvas.tsx
+++ b/web/components/agent-visualizer/canvas.tsx
@@ -59,6 +59,11 @@ interface CanvasProps {
    *  prop so callers can pass it without a type error; future per-session
    *  overlays (cost, badges) can read it. */
   sessionId?: string
+  /** User-set custom name for this session's main/orchestrator agent (from
+   *  useSessionNames). When defined, the main agent's hex draws this string
+   *  as its primary label with "Orchestrator" as a subtitle. When undefined,
+   *  the main agent draws "Orchestrator" alone. */
+  customMainAgentName?: string
   /** When true (default), pause the render rAF when the canvas scrolls
    *  off-screen. The simulation sub-state keeps ticking so stats panels
    *  still receive fresh data. */
@@ -70,6 +75,7 @@ export function AgentCanvas({
   selectedAgentId, hoveredAgentId, showStats, showHexGrid, zoomToFitTrigger, pauseAutoFit,
   onAgentClick, onAgentHover, onAgentDrag, onContextMenu, onToolCallClick, selectedToolCallId, onDiscoveryClick, selectedDiscoveryId, showCostOverlay,
   bloomEnabled = true, bloomThrottle = 1, minZoomLevel, pauseWhenOffscreen = true,
+  customMainAgentName,
 }: CanvasProps) {
   const manager = useSimulationManager()
   const containerRef = useRef<HTMLDivElement>(null)
@@ -138,6 +144,7 @@ export function AgentCanvas({
     simTime: sim.currentTime, pauseAutoFit, dimensions,
     onAgentDrag, onAgentClick, onAgentHover, onContextMenu,
     onToolCallClick, onDiscoveryClick,
+    customMainAgentName,
     isDragging: false,
   })
 
@@ -162,6 +169,7 @@ export function AgentCanvas({
     p.onContextMenu = onContextMenu
     p.onToolCallClick = onToolCallClick
     p.onDiscoveryClick = onDiscoveryClick
+    p.customMainAgentName = customMainAgentName
   }
 
   // ─── Camera ─────────────────────────────────────────────────────────────
@@ -320,6 +328,7 @@ export function AgentCanvas({
         selectedAgentId, hoveredAgentId, showStats, showHexGrid,
         showCostOverlay, selectedToolCallId, selectedDiscoveryId,
         simTime, pauseAutoFit, dimensions, onAgentDrag,
+        customMainAgentName,
         isDragging,
       } = drawPropsRef.current
       const transform = transformRef.current
@@ -407,7 +416,7 @@ export function AgentCanvas({
         drawEdges(ctx, edges, agents, toolCalls, activeEdgeIds, timeRef.current, viewBounds)
         drawToolCalls(ctx, toolCalls, timeRef.current, selectedToolCallId, viewBounds)
         drawDiscoveries(ctx, discoveries, agents, selectedDiscoveryId, viewBounds)
-        drawAgents(ctx, agents, selectedAgentId, hoveredAgentId, showStats, timeRef.current)
+        drawAgents(ctx, agents, selectedAgentId, hoveredAgentId, showStats, timeRef.current, customMainAgentName)
         drawMessageBubblesWorld(ctx, agents, simTimeRef.current)
         if (showCostOverlay) drawCostLabels(ctx, agents, toolCalls)
         drawParticles(ctx, particles, edgeMap, agents, toolCalls, timeRef.current, viewBounds)

--- a/web/components/agent-visualizer/canvas/draw-agents.ts
+++ b/web/components/agent-visualizer/canvas/draw-agents.ts
@@ -132,6 +132,7 @@ export function drawContextComposition(
   ctx: CanvasRenderingContext2D,
   agent: Agent,
   radius: number,
+  extendedLayout: boolean,
 ) {
   const bd = agent.contextBreakdown
   const total = agent.tokensUsed
@@ -140,7 +141,7 @@ export function drawContextComposition(
   const barWidth = Math.max(CONTEXT_BAR.minWidth, radius * CONTEXT_BAR.widthMultiplier)
   const barHeight = CONTEXT_BAR.barHeight
   const barX = agent.x - barWidth / 2
-  const barY = agent.y + radius + CONTEXT_BAR.yOffset
+  const barY = agent.y + radius + (extendedLayout ? CONTEXT_BAR.yOffsetWithSubtitle : CONTEXT_BAR.yOffset)
 
   // Background
   ctx.fillStyle = COLORS.cardBgDark
@@ -377,14 +378,30 @@ function drawWaitingRipples(ctx: CanvasRenderingContext2D, agent: Agent, r: numb
   }
 }
 
-function drawAgentLabel(ctx: CanvasRenderingContext2D, agent: Agent, r: number, isHovered: boolean) {
+function drawAgentLabel(ctx: CanvasRenderingContext2D, agent: Agent, r: number, isHovered: boolean, customMainAgentName: string | undefined) {
   const labelFont = '10px monospace'
   const labelColor = isHovered ? COLORS.textPrimary : COLORS.textDim
   ctx.font = labelFont // needed for truncateText measurement
   const maxLabelW = r * AGENT_DRAW.labelWidthMultiplier
+  const labelY = agent.y + r + AGENT_DRAW.labelYOffset
+
+  if (agent.isMain) {
+    const customName = (customMainAgentName ?? '').trim()
+    const isCustom = customName.length > 0 && customName.toLowerCase() !== 'orchestrator'
+    const primary = truncateText(ctx, isCustom ? customName : 'Orchestrator', maxLabelW)
+    const primarySprite = getTextSprite(primary, labelFont, labelColor, 'center', 'top')
+    drawTextSprite(ctx, primarySprite, agent.x, labelY, 'center', 'top')
+    if (isCustom) {
+      const subtitleFont = '8px monospace'
+      const subtitleSprite = getTextSprite('Orchestrator', subtitleFont, COLORS.textMuted, 'center', 'top')
+      drawTextSprite(ctx, subtitleSprite, agent.x, labelY + 12, 'center', 'top')
+    }
+    return
+  }
+
   const agentLabel = truncateText(ctx, agent.name, maxLabelW)
   const labelSprite = getTextSprite(agentLabel, labelFont, labelColor, 'center', 'top')
-  drawTextSprite(ctx, labelSprite, agent.x, agent.y + r + AGENT_DRAW.labelYOffset, 'center', 'top')
+  drawTextSprite(ctx, labelSprite, agent.x, labelY, 'center', 'top')
 }
 
 function drawStatsOverlay(ctx: CanvasRenderingContext2D, agent: Agent, r: number) {
@@ -427,7 +444,10 @@ export function drawAgents(
   hoveredAgentId: string | null,
   showStats: boolean,
   time: number,
+  customMainAgentName: string | undefined,
 ) {
+  const customNameTrimmed = (customMainAgentName ?? '').trim()
+  const isCustom = customNameTrimmed.length > 0 && customNameTrimmed.toLowerCase() !== 'orchestrator'
   for (const [id, agent] of agents) {
     const radius = agent.isMain ? NODE.radiusMain : NODE.radiusSub
     const color = getStateColor(agent.state)
@@ -461,14 +481,14 @@ export function drawAgents(
       drawWaitingRipples(ctx, agent, r, color, time)
     }
 
-    drawAgentLabel(ctx, agent, r, isHovered)
+    drawAgentLabel(ctx, agent, r, isHovered, customMainAgentName)
 
     // Context composition — ring for main agent, bar for sub-agents
     if (agent.state !== 'complete' || agent.opacity > 0.5) {
       if (agent.isMain) {
         drawContextRing(ctx, agent, r, time)
       }
-      drawContextComposition(ctx, agent, r)
+      drawContextComposition(ctx, agent, r, agent.isMain && isCustom)
     }
 
     if (showStats && agent.state !== 'complete') {

--- a/web/components/agent-visualizer/session-canvas-panel.tsx
+++ b/web/components/agent-visualizer/session-canvas-panel.tsx
@@ -275,6 +275,7 @@ function SessionCanvasPanelImpl({
           <AgentCanvas
             simulationRef={sim.frameRef}
             sessionId={sessionId}
+            customMainAgentName={getName(sessionId)}
             selectedAgentId={selectedAgentId}
             hoveredAgentId={hoveredAgentId}
             showStats={showStats}

--- a/web/hooks/simulation/handle-message-events.ts
+++ b/web/hooks/simulation/handle-message-events.ts
@@ -1,6 +1,6 @@
 import type { ContextBreakdown } from '@/lib/agent-types'
 import type { ConversationMessage } from './types'
-import { appendConversation, asString, asNumber, LABEL_LEN_NAME, LABEL_LEN_TASK, LABEL_LEN_BUBBLE, MAX_BUBBLES } from './types'
+import { appendConversation, asString, asNumber, LABEL_LEN_BUBBLE, MAX_BUBBLES } from './types'
 import type { MutableEventState } from './process-event'
 
 export function handleMessage(
@@ -17,15 +17,6 @@ export function handleMessage(
     role === 'user' ? 'user' :
     role === 'thinking' ? 'thinking' :
     'assistant'
-
-  // Rename main agent to the first user message (more recognizable than "orchestrator")
-  if (role === 'user') {
-    const msgAgentForName = state.agents.get(agentName)
-    if (msgAgentForName && msgAgentForName.isMain && msgAgentForName.name === agentName) {
-      const shortName = content.slice(0, LABEL_LEN_NAME).replace(/\n/g, ' ').trim()
-      state.agents.set(agentName, { ...msgAgentForName, name: shortName || agentName, task: content.slice(0, LABEL_LEN_TASK) })
-    }
-  }
 
   // Update agent state and push message bubble to queue
   const msgAgent = state.agents.get(agentName)

--- a/web/lib/canvas-constants.ts
+++ b/web/lib/canvas-constants.ts
@@ -218,6 +218,8 @@ export const CONTEXT_BAR = {
   barHeight: 6,
   /** Y offset from agent radius */
   yOffset: 22,
+  /** Y offset when the agent label has a two-line treatment (custom name + "Orchestrator" subtitle). */
+  yOffsetWithSubtitle: 36,
   borderRadius: 3,
   /** Font for token count label */
   fontSize: 7,


### PR DESCRIPTION
## Summary
- Drops the auto-rename block in \`handle-message-events.ts\` that overwrote the orchestrator's name with the first user message. Lots of canvases ended up labeled with truncated prompt fragments like \`lets explore h...\` which were noisy and unhelpful.
- Default label under the orchestrator hex is now \`Orchestrator\`.
- Users can rename the session via the existing title-bar rename mechanism (\`useSessionNames\`). When set, the rename appears as the primary label and \`Orchestrator\` is shown smaller below as a role subtitle.
- Adds \`yOffsetWithSubtitle: 36\` to \`CONTEXT_BAR\` so the token bar slides down when the two-line label is active.

## Test plan
- [ ] Open a fresh session → orchestrator hex shows \`Orchestrator\` (no subtitle).
- [ ] Rename the session via the canvas window's title bar → primary label updates to the new name; smaller \`Orchestrator\` subtitle appears below it; token bar shifts down to clear.
- [ ] Clear the rename (empty string) → reverts to single-line \`Orchestrator\`.
- [ ] Subagent labels (non-main) still render as before (no subtitle).
- [ ] \`pnpm tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)